### PR TITLE
Handle timezone from TZ variable

### DIFF
--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -186,7 +186,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 USE_TZ = True
-TIME_ZONE = "UTC"
+TIME_ZONE = os.getenv('TZ', 'UTC')
 
 # We do not currently support internationalization and localization, turn these
 # off.


### PR DESCRIPTION
Timezone should not be set in hard, but can be overrided by common TZ environment variable 