### PR TITLE
Removed unneeded autoescape.

### DIFF
--- a/ara/ui/templates/playbook.html
+++ b/ara/ui/templates/playbook.html
@@ -17,7 +17,7 @@
                     {% for arg, value in playbook.arguments.items %}
                     <tr>
                         <td>{{ arg }}</td>
-                        <td>{% autoescape on %}{{ value }}{% endautoescape %}</td>
+                        <td>{{ value }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>


### PR DESCRIPTION
Django does autoescaping by default. I also verified by putting `<script>alert(document.cookie);</script>` in a playbook argument and it ends up escaped as expected. If your smoke test where able to find something here I'd be very much interested to know what :)