### PR TITLE
Ensure endpoint doesn't contain trailing slash

### DIFF
--- a/ara/clients/http.py
+++ b/ara/clients/http.py
@@ -34,7 +34,7 @@ class HttpClient(object):
     def __init__(self, endpoint="http://127.0.0.1:8000", timeout=30, auth=None):
         self.log = logging.getLogger(__name__)
 
-        self.endpoint = endpoint
+        self.endpoint = endpoint.rstrip("/")
         self.timeout = timeout
         self.headers = {
             "User-Agent": "ara-http-client_%s" % CLIENT_VERSION,


### PR DESCRIPTION
If api_server is configured with trailing slash as "http://localhost/" it causes failures and it's difficult to investigate. Ensure it doesn't happen and endpoint is always without trailing slash.