### PR TITLE
Fixed typo in ara.setup.env

### DIFF
--- a/ara/setup/env.py
+++ b/ara/setup/env.py
@@ -24,7 +24,7 @@ from . import action_plugins, callback_plugins
 
 exports = """
 export ANSIBLE_CALLBACK_PLUGINS=${{ANSIBLE_CALLBACK_PLUGINS:-}}${{ANSIBLE_CALLBACK_PLUGINS+:}}{}
-export ANSIBLE_ACTION_PLUGINS=${{ANSIBLE_ACTION_PLUGINS:-}}${{ANSIBLE_CALLBACK_PLUGINS+:}}{}
+export ANSIBLE_ACTION_PLUGINS=${{ANSIBLE_ACTION_PLUGINS:-}}${{ANSIBLE_ACTION_PLUGINS+:}}{}
 """.format(
     callback_plugins, action_plugins
 )


### PR DESCRIPTION
This typo breaks local modules (in a playbook's ./library for ex.) by making modules mistaken for action plugins in Ansible 2.9.1.