### PR TITLE
ui: use relative links for pagination

### DIFF
--- a/ara/ui/pagination.py
+++ b/ara/ui/pagination.py
@@ -26,18 +26,42 @@ class LimitOffsetPaginationWithLinks(LimitOffsetPagination):
     """
     Extends LimitOffsetPagination to provide links
     to first and last pages as well as the limit and offset, if available.
+    Generates relative links instead of absolute URIs.
     """
+
+    def get_next_link(self):
+        if self.offset + self.limit >= self.count:
+            return None
+
+        url = self.request.get_full_path()
+        url = replace_query_param(url, self.limit_query_param, self.limit)
+
+        offset = self.offset + self.limit
+        return replace_query_param(url, self.offset_query_param, offset)
+
+    def get_previous_link(self):
+        if self.offset <= 0:
+            return None
+
+        url = self.request.get_full_path()
+        url = replace_query_param(url, self.limit_query_param, self.limit)
+
+        if self.offset - self.limit <= 0:
+            return remove_query_param(url, self.offset_query_param)
+
+        offset = self.offset - self.limit
+        return replace_query_param(url, self.offset_query_param, offset)
 
     def get_first_link(self):
         if self.offset <= 0:
             return None
-        url = self.request.build_absolute_uri()
+        url = self.request.get_full_path()
         return remove_query_param(url, self.offset_query_param)
 
     def get_last_link(self):
         if self.offset + self.limit >= self.count:
             return None
-        url = self.request.build_absolute_uri()
+        url = self.request.get_full_path()
         url = replace_query_param(url, self.limit_query_param, self.limit)
         offset = self.count - self.limit
         return replace_query_param(url, self.offset_query_param, offset)


### PR DESCRIPTION
These were being generated as e.g. `http://localhost:8000/?limit=100&offset=100`, while the rest of the links in the UI are relative paths like `playbook/1.html`.

Since I'm not accessing the UI from localhost this caused some breakage.