### PR TITLE
WIP: ui: add highlighted line on file line anchor

### DIFF
--- a/ara/ui/templates/file.html
+++ b/ara/ui/templates/file.html
@@ -11,4 +11,20 @@
         {{ file.content | format_yaml | safe }}
     </div>
 </div>
+
+{# TODO: The version of jquery can change depending on the version of DRF #}
+<script src="{% if page != 'index' %}../{% endif %}static/rest_framework/js/jquery-3.4.1.min.js"></script>
+<script>
+    $(document).ready(function () {
+        // Highlight the anchor line in file views
+        var hash = $(location).attr('hash');
+        $(hash).closest('span').addClass('hll');
+        // Refresh the highlighted line when clicking on a new line in file views
+        $('a').click(function(){
+            $("span.hll").removeClass('hll');
+            var hash = $(this).attr('href');
+            $(hash).closest('span').addClass('hll');
+        });
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
### Exported from gerrit: https://review.opendev.org/c/recordsansible/ara/+/731999

This is a regression from 0.x.

When clicking on a link to a file with a line number anchor, we are now
properly focusing on the line and it is highlighted in yellow.

Change-Id: I7377ea2276315e323d915a6c341a241e88db59f2