### PR TITLE
zuul: add integration test jobs back in

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -12,3 +12,59 @@
     nodeset: fedora-latest-1vcpu
     vars:
       tox_envlist: linters
+
+- job:
+    name: ara-integration-base
+    parent: base
+    files:
+      - ara/*
+      - manage.py
+      - requirements.txt
+      - roles/*
+      - setup.cfg
+      - setup.py
+      - test-requirements.txt
+      - tests/*
+      - tox.ini
+      - .zuul.d/*
+    vars:
+      ara_api_source: "{{ ansible_user_dir }}/src/github.com/ansible-community/ara"
+      ara_tests_ansible_name: "{{ ansible_user_dir }}/src/github.com/ansible/ansible"
+      ara_tests_ansible_version: null
+      ara_api_secure_logging: false
+    post-run: tests/zuul_post_logs.yaml
+
+- job:
+    name: ara-ansible-integration-base
+    parent: ara-integration-base
+    nodeset: fedora-latest-1vcpu
+    vars:
+      ara_api_source: "{{ ansible_user_dir }}/src/github.com/ansible-community/ara"
+    run: tests/basic.yaml
+
+- job:
+    name: ara-basic-ansible-devel
+    parent: ara-ansible-integration-base
+    description: |
+      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with Ansible devel.
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: devel
+
+- job:
+    name: ara-basic-ansible-2.9
+    parent: ara-ansible-integration-base
+    description: |
+      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with Ansible 2.9.
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+
+- job:
+    name: ara-basic-ansible-2.8
+    parent: ara-ansible-integration-base
+    description: |
+      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with Ansible 2.8.
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.8

--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -1,0 +1,14 @@
+---
+- job:
+    name: ara-tox-py3
+    parent: tox
+    nodeset: fedora-latest-1vcpu
+    vars:
+      tox_envlist: py3
+
+- job:
+    name: ara-tox-linters
+    parent: tox
+    nodeset: fedora-latest-1vcpu
+    vars:
+      tox_envlist: linters

--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -14,6 +14,10 @@
       tox_envlist: linters
 
 - job:
+    name: ara-tox-docs
+    parent: ansible-tox-docs
+
+- job:
     name: ara-integration-base
     parent: base
     files:

--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -39,6 +39,14 @@
     post-run: tests/zuul_post_logs.yaml
 
 - job:
+    name: ara-container-images
+    parent: ara-integration-base
+    nodeset: fedora-latest-1vcpu
+    description: |
+      Builds ARA API container images with buildah and briefly tests them with podman.
+    run: tests/with_container_images.yaml
+
+- job:
     name: ara-ansible-integration-base
     parent: ara-integration-base
     nodeset: fedora-latest-1vcpu

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -9,6 +9,7 @@
             voting: false
         - ara-basic-ansible-2.9
         - ara-basic-ansible-2.8
+        - ara-container-images
     gate:
       jobs:
         - ara-tox-py3
@@ -16,3 +17,4 @@
         - ara-tox-docs
         - ara-basic-ansible-2.9
         - ara-basic-ansible-2.8
+        - ara-container-images

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,7 +1,10 @@
+---
 - project:
     check:
       jobs:
-        - noop
+        - ara-tox-py3
+        - ara-tox-linters
     gate:
       jobs:
-        - noop
+        - ara-tox-py3
+        - ara-tox-linters

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -4,7 +4,13 @@
       jobs:
         - ara-tox-py3
         - ara-tox-linters
+        - ara-basic-ansible-devel:
+            voting: false
+        - ara-basic-ansible-2.9
+        - ara-basic-ansible-2.8
     gate:
       jobs:
         - ara-tox-py3
         - ara-tox-linters
+        - ara-basic-ansible-2.9
+        - ara-basic-ansible-2.8

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -4,6 +4,7 @@
       jobs:
         - ara-tox-py3
         - ara-tox-linters
+        - ara-tox-docs
         - ara-basic-ansible-devel:
             voting: false
         - ara-basic-ansible-2.9
@@ -12,5 +13,6 @@
       jobs:
         - ara-tox-py3
         - ara-tox-linters
+        - ara-tox-docs
         - ara-basic-ansible-2.9
         - ara-basic-ansible-2.8

--- a/tests/with_container_images.yaml
+++ b/tests/with_container_images.yaml
@@ -20,7 +20,7 @@
   gather_facts: yes
   vars:
     ara_api_root_dir: "{{ ansible_user_dir }}/.ara-tests"
-    ara_api_source: "{{ ansible_user_dir }}/src/opendev.org/recordsansible/ara"
+    ara_api_source: "{{ ansible_user_dir }}/src/github.com/ansible-community/ara"
     images:
       # These are in chronological order of release so that we don't end up
       # running SQL migrations backwards during the tests.


### PR DESCRIPTION
These are the same jobs as before, just adding them back in.