### PR TITLE
output context with newlines in plaintext diff

### DIFF
--- a/ara/ui/templatetags/diff_result.py
+++ b/ara/ui/templatetags/diff_result.py
@@ -13,7 +13,7 @@ def diff_format_string(plaintext):
     output = []
     for line in plaintext.splitlines():
         output.append(line)
-    return '\n'.join(output)
+    return "\n".join(output)
 
 
 def render_diff(before="", after="", before_header="before", after_header="after"):

--- a/ara/ui/templatetags/diff_result.py
+++ b/ara/ui/templatetags/diff_result.py
@@ -8,6 +8,11 @@ from django import template
 
 register = template.Library()
 
+def diff_format_string(plaintext):
+    output = []
+    for line in plaintext.splitlines():
+        output.append(line)
+    return '\n'.join(output)
 
 def render_diff(before="", after="", before_header="before", after_header="after"):
     """
@@ -24,13 +29,12 @@ def render_diff(before="", after="", before_header="before", after_header="after
         )
     else:
         return difflib.unified_diff(
-            before.splitlines(),
-            after.splitlines(),
+            diff_format_string(before),
+            diff_format_string(after),
             fromfile=before_header,
             tofile=after_header
         )
     # fmt: on
-
 
 @register.filter(name="diff_result")
 def diff_result(diff):

--- a/ara/ui/templatetags/diff_result.py
+++ b/ara/ui/templatetags/diff_result.py
@@ -8,11 +8,13 @@ from django import template
 
 register = template.Library()
 
+
 def diff_format_string(plaintext):
     output = []
     for line in plaintext.splitlines():
         output.append(line)
     return '\n'.join(output)
+
 
 def render_diff(before="", after="", before_header="before", after_header="after"):
     """
@@ -35,6 +37,7 @@ def render_diff(before="", after="", before_header="before", after_header="after
             tofile=after_header
         )
     # fmt: on
+
 
 @register.filter(name="diff_result")
 def diff_result(diff):


### PR DESCRIPTION
The problem with current implementation is that diff output in e.g. bash scripts is showing up as a big string instead of formatted lines (I'm using ARA 1.4.3). Using the `diff_format_string` function should output a formatted result.