### PR TITLE
zuul: set project merge mode to squash-merge

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,5 +1,6 @@
 ---
 - project:
+    merge-mode: squash-merge
     check:
       jobs:
         - ara-tox-py3


### PR DESCRIPTION
So Zuul doesn't end up merging every commit from a PR individually but
rather squash them.