### PR TITLE
Pin dynaconf to <4.0.0 and exclude 3.1.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,8 @@ server=
     django-cors-headers
     django-filter
     django-health-check
-    dynaconf[yaml]
+    # dynaconf 3.1.3 had a regression https://github.com/ansible-community/ara/issues/212
+    dynaconf[yaml]>=3.0.0,!=3.1.3,<4.0.0
     tzlocal
     whitenoise
     pygments


### PR DESCRIPTION
This will allow us to prevent unexpected backwards compatibility when
4.0.0 releases and 3.1.3 had a known regression.

Fixes: https://github.com/ansible-community/ara/issues/212