### PR TITLE
zuul: add pre-release/release job for publishing to pypi

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -18,6 +18,16 @@
     parent: ansible-tox-docs
 
 - job:
+    name: ara-release-pypi
+    parent: python-upload-pypi
+    vars:
+      release_python: python3
+    secrets:
+      - name: pypi_info
+        secret: ara_pypi_token
+        pass-to-parent: true
+
+- job:
     name: ara-integration-base
     parent: base
     files:

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -19,3 +19,9 @@
         - ara-basic-ansible-2.9
         - ara-basic-ansible-2.8
         - ara-container-images
+    pre-release:
+      jobs:
+        - ara-release-pypi
+    release:
+      jobs:
+        - ara-release-pypi

--- a/.zuul.d/secrets.yaml
+++ b/.zuul.d/secrets.yaml
@@ -1,0 +1,15 @@
+- secret:
+    name: ara_pypi_token
+    data:
+      username: __token__
+      password: !encrypted/pkcs1-oaep
+        - fdadpkMg7TtrBYmVn54sNW/Mnp98K8IwB76j5bTmcbAZpZD1LJLZYsxGoGxfMFvWYewna
+          ORfUbgU5zQJO147DA2o8m5MHOKrQz1YIjayTx2cuYKz91v26IOxFa/98B6QjJDgjSkncG
+          ZWcoLukzvXJ9kcz9WMOdRNEaF1DFJaVkvNTqNcnJLAAFApBSB2xvxfT3OALIDwrXerfhg
+          bjiFxGY2BfGm6ncJsLXG9LKB95QqQ+nlIFcLEH9CItoMBCIF2bzF2yzLLGPjzGlXIeMAg
+          ApopwubIIrsjzq6mY3+VoU/hKAcu63zF+VY13gOpTzsH5Lbhr25FiShshruTXSe8+lPG8
+          SC3IV0Rsz7Ar5R/v8wSx9v4tlgxSFS/N3lFGW+XoNZl8LT0Sr2YvbQ84cffCOri1DRPFd
+          F0uidIlKnjsCSHsB4FxrzRGsywMFaHK7kJzj22b1VTXye0tQ6do9elEnLNIbCovXyuPwn
+          ZQgQ/5P2atBEyv/FvUc1DGHoJ9HoGiaMUiTfxbnEAr39Qjzrnvpvjik+pj1KiHm0H1uhT
+          CdPf3UDM2INTcwbMoqnjCqTcOSDUb4kQ1aukAnOFjh+aje0Fns41c07GoYfPt0+LSOp+A
+          dfm9vRzle/ny0t/DEaPvlF8n3UvfLh8+zp6WqiBgZZHtLe29aeGQ1KL0qLjlRw=


### PR DESCRIPTION
Releases were previously automated through OpenDev's Zuul and this is a
first attempt at reproducing the same implementation in Ansible's Zuul.