### PR TITLE
api: don't exclude arguments from playbook parent references

### DIFF
--- a/ara/api/serializers.py
+++ b/ara/api/serializers.py
@@ -87,8 +87,9 @@ class SimpleLabelSerializer(serializers.ModelSerializer):
 class SimplePlaybookSerializer(ItemCountSerializer):
     class Meta:
         model = models.Playbook
-        exclude = ("arguments", "created", "updated")
+        exclude = ("created", "updated")
 
+    arguments = ara_fields.CompressedObjectField(default=ara_fields.EMPTY_DICT, read_only=True)
     labels = SimpleLabelSerializer(many=True, read_only=True, default=[])
 
 

--- a/ara/api/tests/tests_file.py
+++ b/ara/api/tests/tests_file.py
@@ -178,3 +178,8 @@ class FileTestCase(APITestCase):
         # Partial match should match both files
         request = self.client.get("/api/v1/files?path=file.yaml")
         self.assertEqual(2, len(request.data["results"]))
+
+    def test_get_playbook_arguments(self):
+        file = factories.FileFactory()
+        request = self.client.get("/api/v1/files/%s" % file.id)
+        self.assertIn("inventory", request.data["playbook"]["arguments"])

--- a/ara/api/tests/tests_host.py
+++ b/ara/api/tests/tests_host.py
@@ -182,3 +182,8 @@ class HostTestCase(APITestCase):
         for field in order_fields:
             request = self.client.get("/api/v1/hosts?order=-%s" % field)
             self.assertEqual(request.data["results"][0]["id"], second_host.id)
+
+    def test_get_playbook_arguments(self):
+        host = factories.HostFactory()
+        request = self.client.get("/api/v1/hosts/%s" % host.id)
+        self.assertIn("inventory", request.data["playbook"]["arguments"])

--- a/ara/api/tests/tests_play.py
+++ b/ara/api/tests/tests_play.py
@@ -198,3 +198,8 @@ class PlayTestCase(APITestCase):
         # Test multiple status
         request = self.client.get("/api/v1/plays?status=running&status=completed")
         self.assertEqual(2, len(request.data["results"]))
+
+    def test_get_playbook_arguments(self):
+        play = factories.PlayFactory()
+        request = self.client.get("/api/v1/plays/%s" % play.id)
+        self.assertIn("inventory", request.data["playbook"]["arguments"])

--- a/ara/api/tests/tests_records.py
+++ b/ara/api/tests/tests_records.py
@@ -185,3 +185,8 @@ class RecordTestCase(APITestCase):
         for field in order_fields:
             request = self.client.get("/api/v1/records?order=-%s" % field)
             self.assertEqual(request.data["results"][0]["id"], second_record.id)
+
+    def test_get_playbook_arguments(self):
+        record = factories.RecordFactory()
+        request = self.client.get("/api/v1/records/%s" % record.id)
+        self.assertIn("inventory", request.data["playbook"]["arguments"])

--- a/ara/api/tests/tests_result.py
+++ b/ara/api/tests/tests_result.py
@@ -284,3 +284,8 @@ class ResultTestCase(APITestCase):
         results = self.client.get("/api/v1/results?changed=false").data["results"]
         self.assertEqual(1, len(results))
         self.assertEqual(results[0]["id"], unchanged_result.id)
+
+    def test_get_playbook_arguments(self):
+        result = factories.ResultFactory()
+        request = self.client.get("/api/v1/results/%s" % result.id)
+        self.assertIn("inventory", request.data["playbook"]["arguments"])

--- a/ara/api/tests/tests_task.py
+++ b/ara/api/tests/tests_task.py
@@ -261,3 +261,8 @@ class TaskTestCase(APITestCase):
         # Test partial match
         request = self.client.get("/api/v1/tasks?path=main.yml")
         self.assertEqual(len(request.data["results"]), 2)
+
+    def test_get_playbook_arguments(self):
+        task = factories.TaskFactory()
+        request = self.client.get("/api/v1/tasks/%s" % task.id)
+        self.assertIn("inventory", request.data["playbook"]["arguments"])


### PR DESCRIPTION
hosts, plays, tasks, results, files and records have references to
their parent playbook in their detailed view (i.e, ``/api/v1/hosts/<id>``)
but until now it didn't include arguments.

It turns out it would be convenient to include the arguments in this
reference so we can have it readily available for providing context.

The arguments are relatively small so it should be fine to make them
available without incurring significant overhead.

Fixes: https://github.com/ansible-community/ara/issues/220