### PR TITLE
zuul: remove squash-merge mode

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,6 +1,5 @@
 ---
 - project:
-    merge-mode: squash-merge
     check:
       jobs:
         - ara-tox-py3


### PR DESCRIPTION
It doesn't work the way I thought it did. It discards all commits and
their messages, leaving only the PR subject and PR number.