### PR TITLE
Move container-fluid class one level higher

### DIFF
--- a/ara/ui/templates/base.html
+++ b/ara/ui/templates/base.html
@@ -58,8 +58,10 @@
 <script src="{% static_url jquery_url %}"></script>
 <script src="{% static_url bootstrap_js_url %}"></script>
 <main role="main">
-  {% block body %}
-  {% endblock %}
+  <div class="container-fluid">
+    {% block body %}
+    {% endblock %}
+  </div>
 </main>
 </body>
 </html>

--- a/ara/ui/templates/file.html
+++ b/ara/ui/templates/file.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% load pygments_highlights %}
 {% block body %}
-  <div class="container-fluid">
+  <div>
     {% include "partials/playbook_card.html" with playbook=file.playbook %}
   </div>
   <br/>
-  <div class="container-fluid">
+  <div>
   <div class="card">
     <div class="card-header">
       <h4>File: {{ file.path }}</h4>

--- a/ara/ui/templates/host.html
+++ b/ara/ui/templates/host.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 {% block body %}
-  <div class="container-fluid">
+  <div>
     {% include "partials/playbook_card.html" with playbook=host.playbook %}
   </div>
   <br/>
-  <div class="container-fluid">
+  <div>
     {% include "partials/host_facts.html" %}
   </div>
   <br/>
-  <div class="container-fluid">
+  <div>
     {% include "partials/host_results.html" %}
   </div>
   <br/>

--- a/ara/ui/templates/index.html
+++ b/ara/ui/templates/index.html
@@ -6,7 +6,6 @@
 
   {% if not static_generation %}
     <form action="{% url 'ui:index' %}" method="get">
-    <div>
     <div class="accordion" id="search_accordion">
       <div class="card">
         <div class="card-header" id="search_form">

--- a/ara/ui/templates/index.html
+++ b/ara/ui/templates/index.html
@@ -6,7 +6,7 @@
 
   {% if not static_generation %}
     <form action="{% url 'ui:index' %}" method="get">
-    <div class="container-fluid">
+    <div>
     <div class="accordion" id="search_accordion">
       <div class="card">
         <div class="card-header" id="search_form">
@@ -88,7 +88,7 @@
     </div>
   {% endif %}
 
-<div class="container-fluid">
+<div>
   {% if not static_generation %}
     {% include "partials/pagination.html" %}
   {% endif %}
@@ -176,7 +176,7 @@
                     </button>
                   </div>
                   <div class="modal-body">
-                    <div class="container-fluid">
+                    <div>
                       <div class="row">
                         {% if playbook.name is not None %}
                           <h5>{{ playbook.name }} @ {{ playbook.started | format_date }}</h5>

--- a/ara/ui/templates/partials/host_results.html
+++ b/ara/ui/templates/partials/host_results.html
@@ -16,7 +16,7 @@
     <form method="get" action="{% url 'ui:host' host.id %}#results">{% endif %}
     <div id="collapse_results" class="collapse show" aria-labelledby="results_card" data-parent="#results">
       <div class="card-body bg-{{ UI_THEME_VARIANT }}">
-        <div class="container-fluid">
+        <div>
           <strong>Summary:</strong>
           {% if host.ok %}
           <a class="badge badge-pill badge-success" style="font-size:0.9em;" {% if not static_generation %}href="{% url 'ui:host' host.id %}?status=ok#results" title="Search ok results for {{ host.name }}"{% endif %}>
@@ -47,7 +47,7 @@
         </div>
         <br />
         {% if not static_generation %}
-          <div class="container-fluid">
+          <div>
             <div class="accordion" id="search_accordion">
               <div class="card">
                 <div class="card-header" id="search_form">
@@ -166,7 +166,7 @@
           </div>
         {% else %}
           <br/>
-          <div class="container-fluid">
+          <div>
             {% if not request.GET %}
               <h2>No recorded results found for this host.</h2>
               <h3>The playbook might have been interrupted or is in progress.</h3>

--- a/ara/ui/templates/partials/host_results.html
+++ b/ara/ui/templates/partials/host_results.html
@@ -180,5 +180,4 @@
     </form>
   </div>
 </div>
-</div>
 <br/>

--- a/ara/ui/templates/partials/playbook_card.html
+++ b/ara/ui/templates/partials/playbook_card.html
@@ -73,7 +73,7 @@
                   </button>
                 </div>
                 <div class="modal-body">
-                  <div class="container-fluid">
+                  <div>
                     <div class="row">
                       {% if playbook.name is not None %}
                         <h5>{{ playbook.name }} @ {{ playbook.started | format_date }}</h5>

--- a/ara/ui/templates/partials/playbook_results.html
+++ b/ara/ui/templates/partials/playbook_results.html
@@ -160,5 +160,4 @@
     </form>
   </div>
 </div>
-</div>
 <br/>

--- a/ara/ui/templates/partials/playbook_results.html
+++ b/ara/ui/templates/partials/playbook_results.html
@@ -17,7 +17,7 @@
     <div id="collapse_results" class="collapse show" aria-labelledby="results_card" data-parent="#results">
       <div class="card-body bg-{{ UI_THEME_VARIANT }}">
         {% if not static_generation %}
-          <div class="container-fluid">
+          <div>
             <div class="accordion" id="search_accordion">
               <div class="card">
                 <div class="card-header" id="search_form">
@@ -146,7 +146,7 @@
           </div>
         {% else %}
           <br/>
-          <div class="container-fluid">
+          <div>
             {% if not request.GET %}
               <h2>No recorded results found.</h2>
               <h3>The playbook might have been interrupted or is in progress.</h3>

--- a/ara/ui/templates/playbook.html
+++ b/ara/ui/templates/playbook.html
@@ -2,11 +2,11 @@
 {% load datetime_formatting %}
 {% load truncatepath %}
 {% block body %}
-  <div class="container-fluid">
+  <div>
     {% include "partials/playbook_card.html" %}
   </div>
   <br/>
-  <div class="container-fluid">
+  <div>
     <div class="row">
       <div class="col-md-6">
         {% include "partials/playbook_hosts.html" %}
@@ -20,7 +20,7 @@
     </div>
   </div>
   <br/>
-  <div class="container-fluid">
+  <div>
     {% include "partials/playbook_results.html" %}
   </div>
 {% endblock %}

--- a/ara/ui/templates/record.html
+++ b/ara/ui/templates/record.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% load pygments_highlights %}
 {% block body %}
-  <div class="container-fluid">
+  <div>
     {% include "partials/playbook_card.html" with playbook=record.playbook %}
   </div>
   <br/>
-  <div class="container-fluid">
+  <div>
   <div class="card">
     <div class="card-header">
       <h4 title="key saved with ara_record">Record: {{ record.key }}</h4>

--- a/ara/ui/templates/result.html
+++ b/ara/ui/templates/result.html
@@ -4,11 +4,11 @@
 {% load diff_result %}
 {% load static_url %}
 {% block body %}
-  <div class="container-fluid">
+  <div>
     {% include "partials/playbook_card.html" with playbook=result.playbook %}
   </div>
   <br/>
-  <div class="container-fluid">
+  <div>
     <div class="card">
       <div class="card-header">
         <h4>Task result details</h4>


### PR DESCRIPTION
There are block alignment errors that distract users.
By putting container-fluid class one level higher, we avoid oversights in the child blocks.
And we improve the alignment of the blocks.