### PR TITLE
Fix pagination margin

### DIFF
--- a/ara/ui/templates/partials/pagination.html
+++ b/ara/ui/templates/partials/pagination.html
@@ -1,5 +1,5 @@
-<nav aria-label="Page navigation">
-  <ul class="pagination justify-content-center">
+<nav aria-label="Page navigation" class="my-3">
+  <ul class="pagination justify-content-center mb-0">
     {% if data.first %}
       <li class="page-item">
         <a class="page-link" href="{{ data.first }}" aria-label="Go to first page">First</a>


### PR DESCRIPTION
Visually to keep the rhythm in the page, the spaces must be consistent.
This PR is there to put the same space above and below the pagination.