### PR TITLE
UI: Tweak search forms and host summary

### DIFF
--- a/ara/ui/templates/index.html
+++ b/ara/ui/templates/index.html
@@ -4,7 +4,8 @@
 {% load static_url %}
 {% block body %}
 
-  {% if not static_generation %}
+{% if not static_generation %}
+  <div class="col-xl-6 offset-xl-3">
     <form action="{% url 'ui:index' %}" method="get">
     <div class="accordion" id="search_accordion">
       <div class="card">
@@ -19,33 +20,33 @@
         <div id="collapse_search" class="{% if expand_search %}show{% endif %} collapse" aria-labelledby="search_form" data-parent="#search_accordion">
           <div class="card-body {% if UI_THEME_VARIANT == 'dark' %}bg-secondary{% endif %}">
             <div class="form-row">
-              <div class="form-group col-md-5">
+              <div class="form-group col-xl-10">
                 <label for="path" {% if request.GET.path %}style="font-weight:bold;"{% endif %}>Path</label>
                 <input type="text" class="form-control" id="path" name="path" placeholder="ex: /path/to/playbook.yml (or) playbook.yml" value="{{ search_form.path.value | default_if_none:'' }}">
               </div>
             </div>
             <div class="form-row">
-              <div class="form-group col-md-2">
+              <div class="form-group col-xl-5">
                 <label for="ansible_version" {% if request.GET.ansible_version %}style="font-weight:bold;"{% endif %}>Ansible version</label>
                 <input type="text" class="form-control" id="ansible_version" name="ansible_version" placeholder="ex: 2.10.5 (or) 2.10" value="{{ search_form.ansible_version.value | default_if_none:'' }}">
               </div>
-              <div class="form-group col-md-3">
+              <div class="form-group col-xl-5">
                 <label for="controller" {% if request.GET.controller %}style="font-weight:bold;"{% endif %}>Ansible controller</label>
                 <input type="text" class="form-control" id="controller" name="controller" placeholder="ex: host.domain.tld (or) host" value="{{ search_form.controller.value | default_if_none:'' }}">
               </div>
             </div>
             <div class="form-row">
-              <div class="form-group col-md-2">
+              <div class="form-group col-xl-5">
                 <label for="name" {% if request.GET.name %}style="font-weight:bold;"{% endif %}>Name</label>
                 <input type="text" class="form-control" id="name" name="name" placeholder="ex: install server" value="{{ search_form.name.value | default_if_none:'' }}">
               </div>
-              <div class="form-group col-md-3">
+              <div class="form-group col-xl-5">
                 <label for="label" {% if request.GET.label %}style="font-weight:bold;"{% endif %}>Label</label>
                 <input type="text" class="form-control" id="label" name="label" placeholder="ex: check:False" value="{{ search_form.label.value | default_if_none:'' }}">
               </div>
             </div>
             <div class="form-row">
-              <div class="form-group col-md-7">
+              <div class="form-group col-xl-12">
                 <label for="status" {% if request.GET.status %}style="font-weight:bold;"{% endif %}>Status: </label>
                 {% for value, text in search_form.status.field.choices %}
                   {% if value != "unknown" %}
@@ -60,7 +61,7 @@
               </div>
             </div>
             <div class="form-row">
-              <div class="col-md-12">
+              <div class="col-xl-12">
                 <div class="btn-group" role="group" aria-label="Filter by date">
                   <button type="submit" class="btn btn-primary">
                     Submit
@@ -74,16 +75,22 @@
                   <button type="submit" class="btn btn-outline-success" name="started_after" value="{% past_timestamp with days=30 %}">Last 30 days
                   </button>
                 </div>
-                {% if request.GET %}
-                  <a class="btn btn-outline-danger" href="{% url 'ui:index' %}" role="button">Reset</a>
-                {% endif %}
               </div>
             </div>
+            {% if request.GET %}
+              <br />
+              <div class="form-row">
+                <div class="col-xl-12">
+                  <a class="btn btn-outline-danger" href="{% url 'ui:index' %}" role="button">Reset</a>
+                </div>
+              </div>
+            {% endif %}
           </div>
         </div>
       </div>
     </div>
-  {% endif %}
+  </div>
+{% endif %}
 
 <div>
   {% if not static_generation %}

--- a/ara/ui/templates/partials/host_facts.html
+++ b/ara/ui/templates/partials/host_facts.html
@@ -2,14 +2,12 @@
 <div class="accordion" id="host_facts">
   <div class="card">
     <div class="card-header" id="host_facts_card">
-      <button class="btn" style="font-size:1.2em;" type="button" data-toggle="collapse" data-target="#collapse_host_facts" aria-expanded="true" aria-controls="collapse_host_facts">
-        <h4>
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
-            <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
-            <path d="M8.93 6.588l-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
-          </svg>
-          Host facts: {{ host.name }}
-        </h4>
+      <button class="btn btn-lg" style="font-size:1.2em;" type="button" data-toggle="collapse" data-target="#collapse_host_facts" aria-expanded="true" aria-controls="collapse_host_facts">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
+          <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+          <path d="M8.93 6.588l-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
+        </svg>
+        Host facts: {{ host.name }}
       </button>
     </div>
     <div id="collapse_host_facts" class="collapse show" aria-labelledby="host_facts_card" data-parent="#host_facts" style="max-height: 300px; overflow-y: auto;">

--- a/ara/ui/templates/partials/host_results.html
+++ b/ara/ui/templates/partials/host_results.html
@@ -13,7 +13,8 @@
       </button>
     </div>
     {% if not static_generation %}
-    <form method="get" action="{% url 'ui:host' host.id %}#results">{% endif %}
+      <form method="get" action="{% url 'ui:host' host.id %}#results">
+    {% endif %}
     <div id="collapse_results" class="collapse show" aria-labelledby="results_card" data-parent="#results">
       <div class="card-body bg-{{ UI_THEME_VARIANT }}">
         <div>
@@ -47,29 +48,27 @@
         </div>
         <br />
         {% if not static_generation %}
-          <div>
+          <div class="col-xl-6 offset-xl-3">
             <div class="accordion" id="search_accordion">
               <div class="card">
                 <div class="card-header" id="search_form">
-                  <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapse_search" aria-expanded="{{ expand_search }}" aria-controls="collapse_search">
-                    <h5>
-                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-search" viewBox="0 0 16 16">
-                        <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"></path>
-                      </svg>
-                      Search and filter
-                    </h5>
+                  <button class="btn btn-link btn-lg" type="button" data-toggle="collapse" data-target="#collapse_search" aria-expanded="{{ expand_search }}" aria-controls="collapse_search">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-search" viewBox="0 0 16 16">
+                      <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"></path>
+                    </svg>
+                    Search and filter
                   </button>
                 </div>
                 <div id="collapse_search" class="{% if expand_search %}show{% endif %} collapse" aria-labelledby="search_form" data-parent="#search_accordion">
                   <div class="card-body {% if UI_THEME_VARIANT == 'dark' %}bg-secondary{% endif %}">
                     <div class="form-row">
-                      <div class="form-group col-md-1">
+                      <div class="form-group col-xl-4">
                         <label for="task" {% if request.GET.task %}style="font-weight:bold;"{% endif %}>Task ID</label>
                         <input type="text" class="form-control" id="task" name="task" placeholder="ex: 1234" value="{{ search_form.task.value | default_if_none:'' }}">
                       </div>
                     </div>
                     <div class="form-row">
-                      <div class="form-group col-md-4">
+                      <div class="form-group col-xl-12">
                         <label for="status" {% if request.GET.status %}style="font-weight:bold;"{% endif %}>Status: </label>
                         {% for value, text in search_form.status.field.choices %}
                           {% if value != "unknown" %}
@@ -84,7 +83,7 @@
                       </div>
                     </div>
                     <div class="form-row">
-                      <div class="form-group col-md-4">
+                      <div class="form-group col-xl-12">
                         <label for="changed" {% if request.GET.changed %}style="font-weight:bold;"{% endif %}>Changed: </label>
                         <div class="form-check form-check-inline">
                           <input class="form-check-input" type="checkbox" id="changed" value="true" name="changed" {% if search_form.changed.value %}checked{% endif %}/>
@@ -95,10 +94,14 @@
                       </div>
                     </div>
                     <div class="form-row">
-                      <div class="form-group col-md-2">
+                      <div class="form-group col-xl-12">
                         <button type="submit" class="btn btn-primary">
                           Submit
                         </button>
+                      </div>
+                    </div>
+                    <div class="form-row">
+                      <div class="form-group col-xl-12">
                         {% if request.GET %}
                           <a class="btn btn-outline-danger" href="{% url 'ui:host' host.id %}#results" role="button">Reset</a>
                         {% endif %}

--- a/ara/ui/templates/partials/host_results.html
+++ b/ara/ui/templates/partials/host_results.html
@@ -3,50 +3,44 @@
 <div class="accordion" id="results">
   <div class="card">
     <div class="card-header" id="results_card">
-      <button class="btn" style="font-size:1.2em;" type="button" data-toggle="collapse" data-target="#collapse_results" aria-expanded="true" aria-controls="collapse_results">
-        <h4>
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-bar-chart-steps" viewBox="0 0 16 16">
-            <path d="M.5 0a.5.5 0 0 1 .5.5v15a.5.5 0 0 1-1 0V.5A.5.5 0 0 1 .5 0zM2 1.5a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-4a.5.5 0 0 1-.5-.5v-1zm2 4a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-7a.5.5 0 0 1-.5-.5v-1zm2 4a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-6a.5.5 0 0 1-.5-.5v-1zm2 4a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-7a.5.5 0 0 1-.5-.5v-1z"/>
-          </svg>
-          Task results: {{ host.name }}
-        </h4>
+      <button class="btn btn-lg" style="font-size:1.2em;" type="button" data-toggle="collapse" data-target="#collapse_results" aria-expanded="true" aria-controls="collapse_results">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-bar-chart-steps" viewBox="0 0 16 16">
+          <path d="M.5 0a.5.5 0 0 1 .5.5v15a.5.5 0 0 1-1 0V.5A.5.5 0 0 1 .5 0zM2 1.5a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-4a.5.5 0 0 1-.5-.5v-1zm2 4a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-7a.5.5 0 0 1-.5-.5v-1zm2 4a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-6a.5.5 0 0 1-.5-.5v-1zm2 4a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-7a.5.5 0 0 1-.5-.5v-1z"/>
+        </svg>
+        Task results: {{ host.name }}
       </button>
+        {% if host.ok %}
+        <a class="badge badge-pill badge-success" style="font-size:0.9em;" {% if not static_generation %}href="{% url 'ui:host' host.id %}?status=ok#results" title="Search ok results for {{ host.name }}"{% endif %}>
+            {{ host.ok }} OK
+        </a>
+        {% endif %}
+        {% if host.changed %}
+        <a class="badge badge-pill badge-warning" style="font-size:0.9em;" {% if not static_generation %}href="{% url 'ui:host' host.id %}?changed=True#results" title="Search changed results for {{ host.name }}"{% endif %}>
+            {{ host.changed }} CHANGED
+        </a>
+        {% endif %}
+        {% if host.failed %}
+        <a class="badge badge-pill badge-danger" style="font-size:0.9em;"
+            {% if not static_generation %}href="{% url 'ui:host' host.id %}?status=failed#results" title="Search failed results for {{ host.name }}"{% endif %}>
+            {{ host.failed }} FAILED
+        </a>
+        {% endif %}
+        {% if host.unreachable %}
+        <a class="badge badge-pill badge-danger" style="font-size:0.9em;" {% if not static_generation %}href="{% url 'ui:host' host.id %}?status=unreachable#results" title="Search unreachable results for {{ host.name }}"{% endif %}>
+            {{ host.unreachable }} UNREACHABLE
+        </a>
+        {% endif %}
+        {% if host.skipped %}
+        <a class="badge badge-pill badge-info" style="font-size:0.9em;" {% if not static_generation %}href="{% url 'ui:host' host.id %}?status=skipped#results" title="Search skipped results for {{ host.name }}"{% endif %}>
+            {{ host.skipped }} SKIPPED
+        </a>
+        {% endif %}
     </div>
     {% if not static_generation %}
       <form method="get" action="{% url 'ui:host' host.id %}#results">
     {% endif %}
     <div id="collapse_results" class="collapse show" aria-labelledby="results_card" data-parent="#results">
       <div class="card-body bg-{{ UI_THEME_VARIANT }}">
-        <div>
-          <strong>Summary:</strong>
-          {% if host.ok %}
-          <a class="badge badge-pill badge-success" style="font-size:0.9em;" {% if not static_generation %}href="{% url 'ui:host' host.id %}?status=ok#results" title="Search ok results for {{ host.name }}"{% endif %}>
-              {{ host.ok }} OK
-          </a>
-          {% endif %}
-          {% if host.changed %}
-          <a class="badge badge-pill badge-warning" style="font-size:0.9em;" {% if not static_generation %}href="{% url 'ui:host' host.id %}?changed=True#results" title="Search changed results for {{ host.name }}"{% endif %}>
-              {{ host.changed }} CHANGED
-          </a>
-          {% endif %}
-          {% if host.failed %}
-          <a class="badge badge-pill badge-danger" style="font-size:0.9em;"
-              {% if not static_generation %}href="{% url 'ui:host' host.id %}?status=failed#results" title="Search failed results for {{ host.name }}"{% endif %}>
-              {{ host.failed }} FAILED
-          </a>
-          {% endif %}
-          {% if host.unreachable %}
-          <a class="badge badge-pill badge-danger" style="font-size:0.9em;" {% if not static_generation %}href="{% url 'ui:host' host.id %}?status=unreachable#results" title="Search unreachable results for {{ host.name }}"{% endif %}>
-              {{ host.unreachable }} UNREACHABLE
-          </a>
-          {% endif %}
-          {% if host.skipped %}
-          <a class="badge badge-pill badge-info" style="font-size:0.9em;" {% if not static_generation %}href="{% url 'ui:host' host.id %}?status=skipped#results" title="Search skipped results for {{ host.name }}"{% endif %}>
-              {{ host.skipped }} SKIPPED
-          </a>
-          {% endif %}
-        </div>
-        <br />
         {% if not static_generation %}
           <div class="col-xl-6 offset-xl-3">
             <div class="accordion" id="search_accordion">

--- a/ara/ui/templates/partials/playbook_results.html
+++ b/ara/ui/templates/partials/playbook_results.html
@@ -13,11 +13,12 @@
       </button>
     </div>
     {% if not static_generation %}
-    <form method="get" action="{% url 'ui:playbook' playbook.id %}#results">{% endif %}
+      <form method="get" action="{% url 'ui:playbook' playbook.id %}#results">
+    {% endif %}
     <div id="collapse_results" class="collapse show" aria-labelledby="results_card" data-parent="#results">
       <div class="card-body bg-{{ UI_THEME_VARIANT }}">
         {% if not static_generation %}
-          <div>
+          <div class="col-xl-6 offset-xl-3">
             <div class="accordion" id="search_accordion">
               <div class="card">
                 <div class="card-header" id="search_form">
@@ -31,17 +32,17 @@
                 <div id="collapse_search" class="{% if expand_search %}show{% endif %} collapse" aria-labelledby="search_form" data-parent="#search_accordion">
                   <div class="card-body {% if UI_THEME_VARIANT == 'dark' %}bg-secondary{% endif %}">
                     <div class="form-row">
-                      <div class="form-group col-md-1">
+                      <div class="form-group col-xl-4">
                         <label for="host" {% if request.GET.host %}style="font-weight:bold;"{% endif %}>Host ID</label>
                         <input type="text" class="form-control" id="host" name="host" placeholder="ex: 1234" value="{{ search_form.host.value | default_if_none:'' }}">
                       </div>
-                      <div class="form-group col-md-1">
+                      <div class="form-group col-xl-4">
                         <label for="task" {% if request.GET.task %}style="font-weight:bold;"{% endif %}>Task ID</label>
                         <input type="text" class="form-control" id="task" name="task" placeholder="ex: 1234" value="{{ search_form.task.value | default_if_none:'' }}">
                       </div>
                     </div>
                     <div class="form-row">
-                      <div class="form-group col-md-4">
+                      <div class="form-group col-xl-12">
                         <label for="status" {% if request.GET.status %}style="font-weight:bold;"{% endif %}>Status: </label>
                         {% for value, text in search_form.status.field.choices %}
                           {% if value != "unknown" %}
@@ -56,7 +57,7 @@
                       </div>
                     </div>
                     <div class="form-row">
-                      <div class="form-group col-md-4">
+                      <div class="form-group col-xl-12">
                         <label for="changed" {% if request.GET.changed %}style="font-weight:bold;"{% endif %}>Changed: </label>
                         <div class="form-check form-check-inline">
                           <input class="form-check-input" type="checkbox" id="changed" value="true" name="changed" {% if search_form.changed.value %}checked{% endif %}/>
@@ -67,15 +68,21 @@
                       </div>
                     </div>
                     <div class="form-row">
-                      <div class="form-group col-md-2">
+                      <div class="form-group col-xl-12">
                         <button type="submit" class="btn btn-primary">
                           Submit
                         </button>
-                        {% if request.GET %}
-                          <a class="btn btn-outline-danger" href="{% url 'ui:playbook' playbook.id %}#results" role="button">Reset</a>
-                        {% endif %}
                       </div>
                     </div>
+                    {% if request.GET %}
+                      <div class="form-row">
+                        <div class="form-group col-xl-12">
+                          {% if request.GET %}
+                            <a class="btn btn-outline-danger" href="{% url 'ui:playbook' playbook.id %}#results" role="button">Reset</a>
+                          {% endif %}
+                        </div>
+                      </div>
+                    {% endif %}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Before:
![Selection_137](https://user-images.githubusercontent.com/1291204/113080161-6def5e80-91a4-11eb-943f-69647e726c17.png)

After:
![Selection_138](https://user-images.githubusercontent.com/1291204/113080167-7182e580-91a4-11eb-9925-2fffcbb0176f.png)

And host summary moved to task results header:
![Selection_139](https://user-images.githubusercontent.com/1291204/113080269-a131ed80-91a4-11eb-85c5-90e4152335fa.png)
