### PR TITLE
ui: Fix header for CLI args in playbook card

### DIFF
--- a/ara/ui/templates/partials/playbook_card.html
+++ b/ara/ui/templates/partials/playbook_card.html
@@ -75,11 +75,14 @@
                 <div class="modal-body">
                   <div>
                     <div class="row">
-                      {% if playbook.name is not None %}
-                        <h5>{{ playbook.name }} @ {{ playbook.started | format_date }}</h5>
-                      {% else %}
-                        <h5>{{ playbook.path | truncatepath:50 }} @ {{ playbook.started | format_date }}</h5>
-                      {% endif %}
+                      <div class="col-md-12">
+                        {% if playbook.name is not None %}
+                          <h5>{{ playbook.name }} @ {{ playbook.started | format_date }}</h5>
+                        {% else %}
+                          <h5>{{ playbook.path | truncatepath:50 }} @ {{ playbook.started | format_date }}</h5>
+                        {% endif %}
+                        </div>
+                      </div>
                     </div>
                     <div class="row">
                       <div class="col-md-12">


### PR DESCRIPTION
0c7d8424187dfa9173f5a50c95ab930f2fcb0704 fixed the header when viewing
CLI args from the playbook index but the one from the playbook card was
forgotten.