### PR TITLE
Remove max height on host facts card

### DIFF
--- a/ara/ui/templates/partials/host_facts.html
+++ b/ara/ui/templates/partials/host_facts.html
@@ -10,7 +10,7 @@
         Host facts: {{ host.name }}
       </button>
     </div>
-    <div id="collapse_host_facts" class="collapse show" aria-labelledby="host_facts_card" data-parent="#host_facts" style="max-height: 300px; overflow-y: auto;">
+    <div id="collapse_host_facts" class="collapse show" aria-labelledby="host_facts_card" data-parent="#host_facts" style="overflow-y: auto;">
       <div class="card-body">
         {% if host.facts.items %}
         <div class="table-responsive">


### PR DESCRIPTION
Host facts card is an accordion, so no need to fix the height of the card.
Maybe you need to think about a way to show users there is a task result card under the host facts card