### PR TITLE
setup.cfg: pin tzlocal to <3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ server=
     django-health-check
     # dynaconf 3.1.3 had a regression https://github.com/ansible-community/ara/issues/212
     dynaconf[yaml]>=3.0.0,!=3.1.3,<4.0.0
-    tzlocal
+    tzlocal<3.0
     whitenoise
     pygments
 postgresql=


### PR DESCRIPTION
tzlocal has a pre-release for 3.0 dating back to 2020 and it breaks when
installing ara with "pip install --pre ara[server]". We can revisit this
if they do end up doing an actual release.