### PR TITLE
ui: Fix truncatepath calculations

### DIFF
--- a/ara/ui/templatetags/truncatepath.py
+++ b/ara/ui/templatetags/truncatepath.py
@@ -40,9 +40,19 @@ def truncatepath(path, count):
     if len(path) < length:
         return path
 
+    if "/" not in path:
+        # Non-paths look better with the end cut off
+        return path[: length - 4] + "..."
+
     dirname, basename = os.path.split(path)
+
+    if len(basename) >= length:
+        # fmt: off
+        return "..." + basename[4 - length:]
+        # fmt: on
+
     while dirname:
-        if len(dirname) + len(basename) < length:
+        if len(dirname) + len(basename) + 4 < length:
             break
         dirlist = dirname.split("/")
         dirlist.pop(0)


### PR DESCRIPTION
`len(dirname) + len(basename)` is 1 less than `len(path)`, so this could end up returning the entire path that was passed in with "..." prepended. Plus, to always return something that is both less than `count` and shorter than the input we need to account for the prepended string and handle the case where the filename on its own is very long.

Some of the things passed to this function are not actually paths but should probably still be shortened.

Before:
![Screenshot_2021-04-15_12-23-57](https://user-images.githubusercontent.com/512266/114905179-a7e87380-9de6-11eb-9ea8-4af51813b29f.png)

After:
![Screenshot_2021-04-15_12-26-28](https://user-images.githubusercontent.com/512266/114905183-a8810a00-9de6-11eb-89f9-7412aa12f99b.png)
