### PR TITLE
ara_playbook/ara_record: set BYPASS_HOST_LOOP to run once

### DIFF
--- a/ara/plugins/action/ara_playbook.py
+++ b/ara/plugins/action/ara_playbook.py
@@ -67,6 +67,9 @@ class ActionModule(ActionBase):
     """ Retrieves either a specific playbook from ARA or the one currently running """
 
     TRANSFERS_FILES = False
+    # BYPASS_HOST_LOOP functions like a forced "run_once" on a task
+    # We don't need to run this module for every host.
+    BYPASS_HOST_LOOP = True
     VALID_ARGS = frozenset(("playbook_id"))
 
     def __init__(self, *args, **kwargs):

--- a/ara/plugins/action/ara_record.py
+++ b/ara/plugins/action/ara_record.py
@@ -135,6 +135,9 @@ class ActionModule(ActionBase):
     """ Record persistent data as key/value pairs in ARA """
 
     TRANSFERS_FILES = False
+    # BYPASS_HOST_LOOP functions like a forced "run_once" on a task
+    # We don't need to run this module for every host.
+    BYPASS_HOST_LOOP = True
     VALID_ARGS = frozenset(("playbook_id", "key", "value", "type"))
     VALID_TYPES = ["text", "url", "json", "list", "dict"]
 


### PR DESCRIPTION
These action plugins interact with the API to get a playbook or add a
key/value record. When run against an inventory of 100 hosts, these
shouldn't be running 100 times as they only need to run once to retrieve
or set the data.