### PR TITLE
Unpin SQLAlchemy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,7 @@ pbr!=2.1.0,>=2.0.0 # Apache-2.0
 
 jinja2>=2.9
 ansible>=2.6.0
-# Pin SQLAlchemy until new release of flask-sqlalchemy
-# https://github.com/pallets/flask-sqlalchemy/issues/707
-SQLAlchemy<1.3.0
+SQLAlchemy
 Flask>=0.11,!=0.12.3
 Flask-SQLAlchemy
 Flask-Migrate


### PR DESCRIPTION
Previously, the SQLAlchemy version was pinned to < 1.3.0 due to
an issue with flask-sqlalchemy. This was fixed long ago, and the
current requirements.txt causes an issue at least with Python 2,
since it installs incompatible combinations of SQLAlchemy and alembic.