### PR TITLE
tests: Add integration test for free strategy

### DIFF
--- a/tests/basic.yaml
+++ b/tests/basic.yaml
@@ -160,6 +160,9 @@
           when:
             - _installed_ansible_version.stdout is version('2.8', '>=')
 
+        - name: Run free strategy test
+          command: "ansible-playbook -vvv {{ _test_root }}/free_strategy.yaml"
+
         - name: Run hosts.yaml integration test
           command: "ansible-playbook -vvv {{ _test_root }}/hosts.yaml"
 

--- a/tests/integration/free_strategy.yaml
+++ b/tests/integration/free_strategy.yaml
@@ -1,0 +1,72 @@
+# Copyright (c) 2021 The ARA Records Ansible authors
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Requires:
+# export ANSIBLE_CALLBACK_PLUGINS=$(python3 -m ara.setup.callback_plugins)
+# export ANSIBLE_ACTION_PLUGINS=$(python3 -m ara.setup.action_plugins)
+# export ANSIBLE_LOOKUP_PLUGINS=$(python3 -m ara.setup.lookup_plugins)
+
+- name: Create hosts
+  hosts: localhost
+  gather_facts: no
+  vars:
+    test_host_count: 10
+  tasks:
+    - name: Add a host to the inventory
+      add_host:
+        ansible_connection: local
+        hostname: "host-{{ item }}"
+        groups: test_hosts
+        # Pseudo-random sleep duration to influence how quickly different hosts complete
+        randomized_sleep_duration: "{{ 3 | random }}"
+      with_sequence: start=1 end={{ test_host_count }}
+
+- name: Run tasks with free strategy
+  hosts: test_hosts
+  strategy: free
+  gather_facts: no
+  tasks:
+    - name: First task
+      command: sleep {{ randomized_sleep_duration }}
+    - name: Second task
+      command: sleep {{ randomized_sleep_duration }}
+    - name: Third task
+      command: sleep {{ randomized_sleep_duration }}
+
+- name: Assert playbook properties
+  hosts: localhost
+  gather_facts: no
+  vars:
+    test_host_count: 10
+  tasks:
+    - name: Retrieve the current playbook so we can get the ID
+      ara_playbook:
+      register: playbook_query
+
+    - name: Search for the free play
+      vars:
+        playbook_id: "{{ playbook_query.playbook.id | string }}"
+      set_fact:
+        play_query: "{{ lookup('ara_api', '/api/v1/plays?name=free&playbook=' + playbook_id) }}"
+
+    - name: Search for the free tasks
+      vars:
+        play_id: "{{ play_query.results[0].id }}"
+      set_fact:
+        free_tasks: "{{ lookup('ara_api', '/api/v1/tasks?play=' + play_id) }}"
+
+    - name: Assert the number of tasks
+      assert:
+        that:
+          - free_tasks.count == 3
+
+    - name: Assert the status of the tasks
+      assert:
+        that:
+          - item.status == 'completed'
+          - item.action == 'command'
+          - item.play == play_query.results[0].id
+          - item['items']['results'] == test_host_count
+      loop: "{{ free_tasks.results }}"
+      loop_control:
+        label: "{{ item.name }}"

--- a/tests/test_tasks.yaml
+++ b/tests/test_tasks.yaml
@@ -88,6 +88,9 @@
     - name: Run lookups.yaml integration test
       command: "ansible-playbook -vvv {{ _test_root }}/lookups.yaml"
 
+    - name: Run free strategy test
+      command: "ansible-playbook -vvv {{ _test_root }}/free_strategy.yaml"
+
     - name: Run hosts.yaml integration test
       command: "ansible-playbook -vvv {{ _test_root }}/hosts.yaml"
 


### PR DESCRIPTION
This ensures that ara records tasks and results properly, even when
using the free strategy.

This is meant to go along with the PR that added the fix: https://github.com/ansible-community/ara/pull/268