### PR TITLE
ui: Change page title dynamically to provide context

### DIFF
--- a/ara/ui/templates/base.html
+++ b/ara/ui/templates/base.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="ARA Records Ansible">
   <meta name="author" content="https://github.com/ansible-community/ara">
-  <title>ARA Records Ansible</title>
+  <title>ara {% block title %}{% endblock %}</title>
 
   {% static 'images/favicon.ico' as favicon_url %}
   <link rel="shortcut icon" href="{% static_url favicon_url %}">

--- a/ara/ui/templates/file.html
+++ b/ara/ui/templates/file.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
 {% load pygments_highlights %}
+{% load truncatepath %}
+
+{% block title %}| File #{{ file.id }}: {{ file.path | truncatepath:75 }}{% endblock %}
 {% block body %}
   <div>
     {% include "partials/playbook_card.html" with playbook=file.playbook %}

--- a/ara/ui/templates/host.html
+++ b/ara/ui/templates/host.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+{% load truncatepath %}
+
+{% block title %}| Host #{{ host.id }}: {{ results.count }} results on {{ host.name }} for {{ host.playbook.path | truncatepath:60 }}{% endblock %}
 {% block body %}
   <div>
     {% include "partials/playbook_card.html" with playbook=host.playbook %}

--- a/ara/ui/templates/index.html
+++ b/ara/ui/templates/index.html
@@ -2,8 +2,10 @@
 {% load datetime_formatting %}
 {% load truncatepath %}
 {% load static_url %}
-{% block body %}
 
+
+{% block title %}| Playbook reports: {{ current_page_results }} of {{ data.count }}{% endblock %}
+{% block body %}
 {% if not static_generation %}
   <div class="col-xl-6 offset-xl-3">
     <form action="{% url 'ui:index' %}" method="get">

--- a/ara/ui/templates/playbook.html
+++ b/ara/ui/templates/playbook.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% load datetime_formatting %}
 {% load truncatepath %}
+
+{% block title %}| Playbook #{{ playbook.id }}: {{ playbook.items.tasks }} task{{ playbook.items.tasks | pluralize }} on {{ playbook.items.hosts }} host{{ playbook.items.hosts | pluralize }} for {{ playbook.path | truncatepath:60 }}{% endblock %}
 {% block body %}
   <div>
     {% include "partials/playbook_card.html" %}

--- a/ara/ui/templates/record.html
+++ b/ara/ui/templates/record.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% load pygments_highlights %}
+
+{% block title %}| Record #{{ record.id }}: {{ record.type }} value for {{ record.key }}{% endblock %}
 {% block body %}
   <div>
     {% include "partials/playbook_card.html" with playbook=record.playbook %}

--- a/ara/ui/templates/result.html
+++ b/ara/ui/templates/result.html
@@ -3,6 +3,8 @@
 {% load datetime_formatting %}
 {% load diff_result %}
 {% load static_url %}
+
+{% block title %}| Result #{{ result.id }}: [{{ result.status }}] {{ result.task.action }} on {{ result.host.name }} for "{{ result.task.name }}"{% endblock %}
 {% block body %}
   <div>
     {% include "partials/playbook_card.html" with playbook=result.playbook %}


### PR DESCRIPTION
The page title was always "ARA Records Ansible" which made it harder to
distinguish particular pages across multiple tabs.

The new titles provide a bit of context and provide summary information.
Uncapitalizing ARA because it's another recursive acronym and the
current logo doesn't capitalize the "ara".