### PR TITLE
ui: Fix page titles when using static generation

### DIFF
--- a/ara/ui/templates/host_index.html
+++ b/ara/ui/templates/host_index.html
@@ -3,7 +3,7 @@
 {% load truncatepath %}
 {% load static_url %}
 
-{% block title %}| Host reports: {{ current_page_results }} of {{ data.count }}{% endblock %}
+{% block title %}| Host reports{% if not static_generation %}: {{ current_page_results }} of {{ data.count }}{% endif %}{% endblock %}
 {% block body %}
 {% if not static_generation %}
   <div class="col-xl-6 offset-xl-3">

--- a/ara/ui/templates/index.html
+++ b/ara/ui/templates/index.html
@@ -4,7 +4,7 @@
 {% load static_url %}
 
 
-{% block title %}| Playbook reports: {{ current_page_results }} of {{ data.count }}{% endblock %}
+{% block title %}| Playbook reports{% if not static_generation %}: {{ current_page_results }} of {{ data.count }}{% endif %}{% endblock %}
 {% block body %}
 {% if not static_generation %}
   <div class="col-xl-6 offset-xl-3">


### PR DESCRIPTION
The index and host_index templates relied on pagination data to provide
context in the page titles. These turned out empty when doing static
generation since there is no pagination there.