### PR TITLE
ui: toggle between API links for hosts and latesthosts

### DIFF
--- a/ara/ui/templates/partials/api_link.html
+++ b/ara/ui/templates/partials/api_link.html
@@ -3,7 +3,12 @@
 {% if page == "index" %}
   <a href="{% url 'playbook-list' %}" class="nav-link" target="_blank">API</a>
 {% elif page == "host_index" %}
+  {# provided by the view, host-list or latesthost-list #}
+  {% if api_link_url == "host-list" %}
+  <a href="{% url 'host-list' %}" class="nav-link" target="_blank">API</a>
+  {% else %}
   <a href="{% url 'latesthost-list' %}" class="nav-link" target="_blank">API</a>
+  {% endif %}
 {% elif playbook.id %}
   <a href="{% url 'playbook-detail' pk=playbook.id %}" class="nav-link" target="_blank">API</a>
 {% elif result.id %}

--- a/ara/ui/views.py
+++ b/ara/ui/views.py
@@ -73,11 +73,13 @@ class HostIndex(generics.RetrieveAPIView):
             filter_type = "HostFilter"
             # TODO: Is there a cleaner way ? Doing this logic in the template seemed complicated.
             checkbox_status = "checked"
+            api_link_url = "host-list"
         else:
             queryset = models.LatestHost.objects.all()
             serializer_type = "DetailedLatestHostSerializer"
             filter_type = "LatestHostFilter"
             checkbox_status = ""
+            api_link_url = "latesthost-list"
 
         # Sort by updated by default so we have the most recently updated at the top
         order = "-updated"
@@ -104,6 +106,7 @@ class HostIndex(generics.RetrieveAPIView):
 
         # fmt: off
         return Response(dict(
+            api_link_url=api_link_url,
             checkbox_status=checkbox_status,
             current_page_results=current_page_results,
             data=response.data,


### PR DESCRIPTION
The API link changes based on the page that is displayed to best fit a
general API call for the resource the user is looking at.

Because the new host index uses latesthosts by default, point to
/api/v1/latesthosts but if all reports are included, provide
/api/v1/hosts instead.