### PR TITLE
ui: highlight delegated tasks in the results table

### DIFF
--- a/ara/ui/templates/partials/host_results.html
+++ b/ara/ui/templates/partials/host_results.html
@@ -146,7 +146,17 @@
                       {% include "partials/result_status_icon.html" with status=result.status %}
                     {% endif %}
                   </td>
-                  <td>{{ host.name }}</td>
+                  <td>
+                    {{ host.name }}
+                    {% if result.delegated_to %}
+                      <span title="task delegated to {{ result.delegated_to.name }}">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
+                          <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+                          <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
+                        </svg>
+                      </span>
+                    {% endif %}
+                  </td>
                   <td nowrap>
                     {% if not static_generation %}
                       {% url 'ui:file' result.task.file as file_url %}

--- a/ara/ui/templates/partials/playbook_results.html
+++ b/ara/ui/templates/partials/playbook_results.html
@@ -134,6 +134,14 @@
                     {% else %}
                       {{ result.host.name }}
                     {% endif %}
+                    {% if result.delegated_to %}
+                      <span title="task delegated to {{ result.delegated_to.name }}">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
+                          <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+                          <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
+                        </svg>
+                      </span>
+                    {% endif %}
                   </td>
                   <td nowrap>
                     {% if not static_generation %}

--- a/ara/ui/views.py
+++ b/ara/ui/views.py
@@ -159,10 +159,13 @@ class Playbook(generics.RetrieveAPIView):
             serializer = serializers.ListResultSerializer(result_filter, many=True)
 
         for result in serializer.data:
-            task_id = result["task"]
-            result["task"] = serializers.SimpleTaskSerializer(models.Task.objects.get(pk=task_id)).data
-            host_id = result["host"]
-            result["host"] = serializers.SimpleHostSerializer(models.Host.objects.get(pk=host_id)).data
+            task = models.Task.objects.get(pk=result["task"])
+            result["task"] = serializers.SimpleTaskSerializer(task).data
+            host = models.Host.objects.get(pk=result["host"])
+            result["host"] = serializers.SimpleHostSerializer(host).data
+            if result["delegated_to"]:
+                delegated = models.Host.objects.get(pk=result["delegated_to"])
+                result["delegated_to"] = serializers.SimpleHostSerializer(delegated).data
         paginated_results = self.get_paginated_response(serializer.data)
 
         if self.paginator.count > (self.paginator.offset + self.paginator.limit):
@@ -219,8 +222,11 @@ class Host(generics.RetrieveAPIView):
             result_serializer = serializers.ListResultSerializer(result_filter, many=True)
 
         for result in result_serializer.data:
-            task_id = result["task"]
-            result["task"] = serializers.SimpleTaskSerializer(models.Task.objects.get(pk=task_id)).data
+            task = models.Task.objects.get(pk=result["task"])
+            result["task"] = serializers.SimpleTaskSerializer(task).data
+            if result["delegated_to"]:
+                delegated = models.Host.objects.get(pk=result["delegated_to"])
+                result["delegated_to"] = serializers.SimpleHostSerializer(delegated).data
         paginated_results = self.get_paginated_response(result_serializer.data)
 
         if self.paginator.count > (self.paginator.offset + self.paginator.limit):


### PR DESCRIPTION
Displaying that a task had been delegated in the details of a result
didn't feel sufficient so we'll highlight it in the result tables as
well.