### PR TITLE
api/ui: restore filtering on latesthost & add nested date filtering

### DIFF
--- a/ara/api/filters.py
+++ b/ara/api/filters.py
@@ -159,7 +159,7 @@ class HostFilter(BaseFilter):
     # fmt: on
 
 
-class LatestHostFilter(django_filters.rest_framework.FilterSet):
+class LatestHostFilter(BaseFilter):
     playbook = django_filters.NumberFilter(field_name="host__playbook__id", lookup_expr="exact")
     name = django_filters.CharFilter(field_name="host__name", lookup_expr="icontains")
     changed__gt = django_filters.NumberFilter(field_name="host__changed", lookup_expr="gt")
@@ -173,19 +173,12 @@ class LatestHostFilter(django_filters.rest_framework.FilterSet):
     unreachable__gt = django_filters.NumberFilter(field_name="host__unreachable", lookup_expr="gt")
     unreachable__lt = django_filters.NumberFilter(field_name="host__unreachable", lookup_expr="lt")
 
-    # We're not inheriting from BaseFilter in order to pass the query for these fields to the nested host instead
-    created_before = django_filters.IsoDateTimeFilter(field_name="host__created", lookup_expr="lte")
-    created_after = django_filters.IsoDateTimeFilter(field_name="host__created", lookup_expr="gte")
-    updated_before = django_filters.IsoDateTimeFilter(field_name="host__updated", lookup_expr="lte")
-    updated_after = django_filters.IsoDateTimeFilter(field_name="host__updated", lookup_expr="gte")
+    host__created_before = django_filters.IsoDateTimeFilter(field_name="host__created", lookup_expr="lte")
+    host__created_after = django_filters.IsoDateTimeFilter(field_name="host__created", lookup_expr="gte")
+    host__updated_before = django_filters.IsoDateTimeFilter(field_name="host__updated", lookup_expr="lte")
+    host__updated_after = django_filters.IsoDateTimeFilter(field_name="host__updated", lookup_expr="gte")
 
     # fmt: off
-    filter_overrides = {
-        django_models.DateTimeField: {
-            'filter_class': django_filters.IsoDateTimeFilter
-        },
-    }
-
     order = django_filters.OrderingFilter(
         fields=(
             ("id", "id"),

--- a/ara/ui/views.py
+++ b/ara/ui/views.py
@@ -92,6 +92,12 @@ class HostIndex(generics.RetrieveAPIView):
             else:
                 order = "host__%s" % order
 
+            if "updated_after" in request.GET:
+                # request.GET is immutable by default, copy it to set host__updated_after instead
+                request.GET = request.GET.copy()
+                request.GET["host__updated_after"] = request.GET["updated_after"]
+                del request.GET["updated_after"]
+
         query = getattr(filters, filter_type)(request.GET, queryset=queryset)
         page = self.paginate_queryset(query.qs.all().order_by(order))
         if page is not None:


### PR DESCRIPTION
commit 982f1a84422654ff31a5a7c1e92ea122a9054e98 made it so we could no
longer filter by created or updated for LatestHost which made it
inconsistent with all the other endpoints.

This adds host__ fields to filter on the nested host fields instead.