### PR TITLE
callback: don't record delegate_to if the task was skipped

### DIFF
--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -546,7 +546,9 @@ class CallbackModule(CallbackBase):
         # Since a single task can be delegated to multiple hosts (ex: looping on a host group and using delegate_to)
         # this must be a list of hosts.
         delegated_to = []
-        if result._task.delegate_to:
+        # The value of result._task.delegate_to doesn't get templated if the task was skipped
+        # https://github.com/ansible/ansible/issues/75339#issuecomment-888724838
+        if result._task.delegate_to and status != "skipped":
             task_uuid = str(result._task._uuid[:36])
             if task_uuid in self.delegation_cache:
                 for delegated in self.delegation_cache[task_uuid]:


### PR DESCRIPTION
When delegate_to is a variable and the task is skipped, Ansible doesn't
template the variable before sending it to the callback.

We can afford to work around this for skipped tasks.