### PR TITLE
Don't record delegate_to for skipped loop items

### DIFF
--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -400,7 +400,10 @@ class CallbackModule(CallbackBase):
         self._update_delegation_cache(result)
 
     def v2_runner_item_on_skipped(self, result):
-        self._update_delegation_cache(result)
+        pass
+        # result._task.delegate_to can end up being a variable from this hook, don't save it.
+        # https://github.com/ansible/ansible/issues/75339
+        # self._update_delegation_cache(result)
 
     def v2_playbook_on_stats(self, stats):
         self.log.debug("v2_playbook_on_stats")

--- a/tests/integration/delegate_to.yaml
+++ b/tests/integration/delegate_to.yaml
@@ -145,3 +145,34 @@
               - ("delegator" in first_delegated.name and "delegated_hostgroup" not in first_delegated.name)
               - ("delegator" in second_delegated.name and "delegated_hostgroup" not in second_delegated.name)
               - ("delegator" in third_delegated.name and "delegated_hostgroup" not in third_delegated.name)
+
+    - name: Validate the fourth test task
+      block:
+        - name: Find the fourth test task
+          set_fact:
+            tasks: "{{ lookup('ara_api', '/api/v1/tasks?name=test4&playbook=' + playbook_id) }}"
+
+        - name: Find the fourth test task result
+          vars:
+            task_id: "{{ tasks.results[0].id }}"
+          set_fact:
+            results: "{{ lookup('ara_api', '/api/v1/results?task=' + task_id) }}"
+
+        - name: Find the hosts for the fourth test task
+          vars:
+            result: "{{ results.results[0] }}"
+          set_fact:
+            host: "{{ lookup('ara_api', '/api/v1/hosts/' + result.host | string) | to_json | from_json }}"
+            delegated_host: "{{ lookup('ara_api', '/api/v1/hosts/' + result.delegated_to[0] | string) | to_json | from_json }}"
+
+        - name: Validate the result for the fourth test task
+          vars:
+            result: "{{ results.results[0] }}"
+          assert:
+            that:
+              - result.host is integer
+              # The hostgroup has three hosts but the condition is made so only one goes through, the other two are skipped
+              - result.delegated_to | length == 1
+              - result.host not in result.delegated_to
+              - host.name == 'localhost'
+              - delegated_host.name == 'delegator-1'

--- a/tests/integration/delegate_to.yaml
+++ b/tests/integration/delegate_to.yaml
@@ -1,38 +1,46 @@
-- name: Create a fake host
+- name: Create fake hosts to test with
+  hosts: localhost
+  gather_facts: no
+  vars:
+    host_count: 3
+  tasks:
+    - name: Add a host to the inventory
+      add_host:
+        hostname: "delegator-{{ item }}"
+        ansible_connection: local
+        ansible_host: 127.0.0.1
+        groups: delegated_hostgroup
+      with_sequence: start=1 end={{ host_count }}
+
+- name: Run a play with delegated tasks
   hosts: localhost
   gather_facts: no
   tasks:
-    - name: Create the host
-      add_host:
-        name: "delegator"
-        ansible_host: "127.0.0.1"
-        ansible_connection: "local"
-
-- name: Run a play with a delegated task
-  hosts: delegator
-  gather_facts: no
-  vars:
-    delegated_hosts:
-      - localhost
-  tasks:
-    - name: Run a normal task
+    - name: test1 - Run a normal task
       command: echo "A normal task"
       changed_when: false
 
-    - name: Run a task with delegate_to
+    - name: test2 - Run a task with delegate_to
       command: echo "A delegated task"
       changed_when: false
-      delegate_to: localhost
+      delegate_to: "delegator-1"
 
     # Test for particular behavior when running a loop task with delegate_to
     # https://github.com/ansible/ansible/issues/75339
-    - name: Run a delegated task with a variable
+    - name: test3 - Run a delegated task with a variable
       command: echo "A delegated task to a variable host"
       changed_when: false
       delegate_to: "{{ item }}"
-      loop: "{{ delegated_hosts }}"
+      loop: "{{ groups['delegated_hostgroup'] }}"
 
-- name: Validate undelegated task
+    - name: test4 - Run a delegated task with a variable inside a conditional loop
+      command: echo "A delegated task with a loop and some skipped elements"
+      changed_when: false
+      delegate_to: "{{ item }}"
+      loop: "{{ groups['delegated_hostgroup'] }}"
+      when: item == "delegator-1"
+
+- name: Validate recorded task results
   hosts: localhost
   gather_facts: no
   tasks:
@@ -40,85 +48,100 @@
       ara_playbook:
       register: playbook_query
 
-    - name: Find the undelegated task
-      vars:
+    - name: Set the playbook id
+      set_fact:
         playbook_id: "{{ playbook_query.playbook.id | string }}"
-      set_fact:
-        tasks: "{{ lookup('ara_api', '/api/v1/tasks?name=normal&playbook=' + playbook_id) }}"
 
-    - name: Find the undelegated result
-      vars:
-        task_id: "{{ tasks.results[0].id }}"
-      set_fact:
-        results: "{{ lookup('ara_api', '/api/v1/results?task=' + task_id) }}"
+    - name: Validate the first test task
+      block:
+        - name: Find the first test task
+          set_fact:
+            tasks: "{{ lookup('ara_api', '/api/v1/tasks?name=test1&playbook=' + playbook_id) }}"
 
-    - name: Validate the result
-      vars:
-        result: "{{ results.results[0] }}"
-      assert:
-        that:
-          - result.host is integer
-          - result.delegated_to == []
+        - name: Find the first test task result
+          vars:
+            task_id: "{{ tasks.results[0].id }}"
+          set_fact:
+            results: "{{ lookup('ara_api', '/api/v1/results?task=' + task_id) }}"
 
-- name: Validate delegated tasks
-  hosts: localhost
-  gather_facts: no
-  tasks:
-    - name: Get the current playbook to retrieve it's id
-      ara_playbook:
-      register: playbook_query
+        - name: Find the host for the first test task
+          vars:
+            result: "{{ results.results[0] }}"
+          set_fact:
+            # FIXME: Uncertain why "to_json | from json" is necessary here. The lookup returns a dict but trying to
+            # access it yields: 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'name'
+            host: "{{ lookup('ara_api', '/api/v1/hosts/' + result.host | string) | to_json | from_json }}"
 
-    - name: Find the delegated task
-      vars:
-        playbook_id: "{{ playbook_query.playbook.id | string }}"
-      set_fact:
-        tasks: "{{ lookup('ara_api', '/api/v1/tasks?name=delegate_to&playbook=' + playbook_id) }}"
+        - name: Validate the result for the first test task
+          vars:
+            result: "{{ results.results[0] }}"
+          assert:
+            that:
+              - result.host is integer
+              - result.delegated_to == []
+              - host.name == "localhost"
 
-    - name: Find the delegated result
-      vars:
-        task_id: "{{ tasks.results[0].id }}"
-      set_fact:
-        results: "{{ lookup('ara_api', '/api/v1/results?task=' + task_id) }}"
+    - name: Validate the second test task
+      block:
+        - name: Find the second test task
+          set_fact:
+            tasks: "{{ lookup('ara_api', '/api/v1/tasks?name=test2&playbook=' + playbook_id) }}"
 
-    - name: Validate the result
-      vars:
-        result: "{{ results.results[0] }}"
-      assert:
-        that:
-          - result.delegated_to is not mapping and result.delegated_to is iterable
-          - result.host is integer
-          - result.host != result.delegated_to[0]
+        - name: Find the second test task result
+          vars:
+            task_id: "{{ tasks.results[0].id }}"
+          set_fact:
+            results: "{{ lookup('ara_api', '/api/v1/results?task=' + task_id) }}"
 
-    - name: Find the other delegated task
-      vars:
-        playbook_id: "{{ playbook_query.playbook.id | string }}"
-      set_fact:
-        tasks: "{{ lookup('ara_api', '/api/v1/tasks?name=variable&playbook=' + playbook_id) }}"
+        - name: Find the host for the second test task
+          vars:
+            result: "{{ results.results[0] }}"
+          set_fact:
+            host: "{{ lookup('ara_api', '/api/v1/hosts/' + result.host | string) | to_json | from_json }}"
+            delegated_host: "{{ lookup('ara_api', '/api/v1/hosts/' + result.delegated_to[0] | string) | to_json | from_json }}"
 
-    - name: Find the other delegated result
-      vars:
-        task_id: "{{ tasks.results[0].id }}"
-      set_fact:
-        results: "{{ lookup('ara_api', '/api/v1/results?task=' + task_id) }}"
+        - name: Validate the result for the second test task
+          vars:
+            result: "{{ results.results[0] }}"
+          assert:
+            that:
+              - result.host is integer
+              - result.delegated_to | length == 1
+              - result.host != result.delegated_to[0]
+              - host.name == "localhost"
+              - delegated_host.name == "delegator-1"
 
-    - name: Retrieve the hosts related to the other delegated task
-      vars:
-        result: "{{ results.results[0] }}"
-      set_fact:
-        first_host: "{{ lookup('ara_api', '/api/v1/hosts/' + result.host | string) }}"
-        second_host: "{{ lookup('ara_api', '/api/v1/hosts/' + result.delegated_to[0] | string) }}"
+    - name: Validate the third test task
+      block:
+        - name: Find the third test task
+          set_fact:
+            tasks: "{{ lookup('ara_api', '/api/v1/tasks?name=test3&playbook=' + playbook_id) }}"
 
-    - name: Validate the other delegated result
-      vars:
-        result: "{{ results.results[0] }}"
-        # TODO: Uncertain why "to_json | from json" is necessary here. The lookup returns a dict but trying to
-        # access it yields: 'ansible.utils.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'name'
-        first: "{{ first_host | to_json | from_json }}"
-        second: "{{ second_host | to_json | from_json }}"
-      assert:
-        that:
-          - result.delegated_to is not mapping and result.delegated_to is iterable
-          - result.host != result.delegated_to[0]
-          - result.delegated_to[0] == second.id
-          - first.name == "delegator"
-          - second.name == "localhost"
+        - name: Find the third test task result
+          vars:
+            task_id: "{{ tasks.results[0].id }}"
+          set_fact:
+            results: "{{ lookup('ara_api', '/api/v1/results?task=' + task_id) }}"
+
+        - name: Find the hosts for the third test task
+          vars:
+            result: "{{ results.results[0] }}"
+          set_fact:
+            host: "{{ lookup('ara_api', '/api/v1/hosts/' + result.host | string) | to_json | from_json }}"
+            first_delegated: "{{ lookup('ara_api', '/api/v1/hosts/' + result.delegated_to[0] | string) | to_json | from_json }}"
+            second_delegated: "{{ lookup('ara_api', '/api/v1/hosts/' + result.delegated_to[1] | string) | to_json | from_json }}"
+            third_delegated: "{{ lookup('ara_api', '/api/v1/hosts/' + result.delegated_to[2] | string) | to_json | from_json }}"
+
+        - name: Validate the result for the third test task
+          vars:
+            result: "{{ results.results[0] }}"
+          assert:
+            that:
+              - result.host is integer
+              - result.delegated_to | length == groups['delegated_hostgroup'] | length
+              - result.host not in result.delegated_to
+              - host.name == 'localhost'
+              # Validate that we have the actual hostnames and not the variable as-is
+              - ("delegator" in first_delegated.name and "delegated_hostgroup" not in first_delegated.name)
+              - ("delegator" in second_delegated.name and "delegated_hostgroup" not in second_delegated.name)
+              - ("delegator" in third_delegated.name and "delegated_hostgroup" not in third_delegated.name)


### PR DESCRIPTION
8df13a99ba41ecac4040db11caa867e2c9c98b72 avoided recording tasks with
delegate_to that had been skipped entirely due to a 'when' condition
because Ansible doesn't template the variable sent to the callback.

It turns out that we also need to avoid recording it for skipped items
while in a loop because the delegate_to also doesn't get templated by
Ansible.
