### PR TITLE
Ensure compatibility with previous ara callback versions

### DIFF
--- a/ara/api/serializers.py
+++ b/ara/api/serializers.py
@@ -348,7 +348,9 @@ class ResultSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
     content = ara_fields.CompressedObjectField(default=ara_fields.EMPTY_DICT)
-    delegated_to = serializers.SlugRelatedField(many=True, slug_field="id", queryset=models.Host.objects.all())
+    delegated_to = serializers.SlugRelatedField(
+        many=True, required=False, slug_field="id", queryset=models.Host.objects.all()
+    )
 
 
 class FileSerializer(FileSha1Serializer):


### PR DESCRIPTION
This PR fixes issue #311.

Through the introduction of the "deleagted_to" field in the result object, the API endpoint `//api/v1/results` expects `delegated_to` as mandatory field in the payload. Because previous ara callback version does not have this ara would not be compatible with older callback versions anymore.

The fix is simple, by only adding a `required=False` in the serializer.