### PR TITLE
setup.cfg: pin psycopg2<2.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,9 @@ server=
     whitenoise
     pygments
 postgresql=
-    psycopg2
+    # Pin psycopg2 until we upgrade to django 3.2 LTS
+    # https://github.com/ansible-community/ara/issues/320
+    psycopg2<2.9
 
 [build_sphinx]
 source-dir = doc/source


### PR DESCRIPTION
psycopg2 2.9 included a change that works with the latest django LTS
(3.2) but breaks 2.2.

Django maintainers have acknowledged the issue and documented that
psycopg2 is supported only through 2.8.6 for Django 2.2:
https://docs.djangoproject.com/en/2.2/ref/databases/#postgresql-notes