### PR TITLE
Disable html forms in browsable api

### DIFF
--- a/ara/api/renderers.py
+++ b/ara/api/renderers.py
@@ -1,0 +1,8 @@
+from rest_framework.renderers import BrowsableAPIRenderer
+
+
+class BrowsableAPIRendererWithoutForms(BrowsableAPIRenderer):
+    """Renders the browsable api, but excludes the forms."""
+
+    def get_rendered_html_form(self, data, view, method, request):
+        return None

--- a/ara/api/renderers.py
+++ b/ara/api/renderers.py
@@ -2,7 +2,30 @@ from rest_framework.renderers import BrowsableAPIRenderer
 
 
 class BrowsableAPIRendererWithoutForms(BrowsableAPIRenderer):
-    """Renders the browsable api, but excludes the forms."""
+    """
+    Renders the browsable api, but excludes the forms.
+
+    If you are running ara in production you will collect a lot of data over time.
+    This will slow down the browsable API
+    because of the population of related keys into the dropdowns of the html POST/PUT form.
+    This is noticed most strongly in the results API view (/api/v1/results or /api/v1/results/X)
+    because there we have a lot of related fields (delegated_to, host, task, play, playbook).
+
+    Using this renderer fixes issue #323.
+
+    To enable this renderer it has to be set in `server/settings.py`:
+
+        REST_FRAMEWORK = {
+            ...
+            "DEFAULT_RENDERER_CLASSES": (
+                ...
+                "ara.api.renderers.BrowsableAPIRendererWithoutForms",
+                ...
+            ),
+            ...
+        }
+
+    """
 
     def get_rendered_html_form(self, data, view, method, request):
         return None

--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -242,7 +242,7 @@ REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
     "DEFAULT_RENDERER_CLASSES": (
         "rest_framework.renderers.JSONRenderer",
-        "rest_framework.renderers.BrowsableAPIRenderer",
+        "ara.api.renderers.BrowsableAPIRendererWithoutForms",
     ),
     "DEFAULT_PARSER_CLASSES": (
         "rest_framework.parsers.JSONParser",


### PR DESCRIPTION
If you are running ara in production you will collect a lot of data over time. This will slow down the browsable API because of the population of related keys into the dropdowns of the html POST/PUT form. 

This is noticed most strongly in the results API view (`/api/v1/results` or `/api/v1/results/X`) because there we have a lot of related fields (delegated_to, host, task, play, playbook). (compare #323)

Because the browsable API is really nice, we need a solution, where we can still browse the API, and also post data if we want, but withouth this huge performance overload.

This code change is based on a anwser on stackoverflow: https://stackoverflow.com/questions/18587726/django-rest-framework-slow-browsable-ui-because-of-large-related-table and just disables the html forms.
That's how the POST/PUT section is looking then:
![image](https://user-images.githubusercontent.com/38468371/128547637-c3f5eb6b-3660-4d16-9843-fabc70ba6e95.png)

Performance Test:
DB with following data:
* hosts: 290,569
* tasks: 408,343
* plays: 10,271
* playbooks:  9,795

loading time of `/api/v1/results` :  
* before: ~ 18.5 s
* after: ~ 3.5 s

