### PR TITLE
server: Handle exception when running psycopg2>=2.9

### DIFF
--- a/ara/server/__main__.py
+++ b/ara/server/__main__.py
@@ -18,6 +18,7 @@
 
 import os
 import sys
+from distutils.version import LooseVersion
 
 from django.conf import settings
 
@@ -26,6 +27,7 @@ from ara.setup.exceptions import (
     MissingMysqlclientException,
     MissingPsycopgException,
     MissingSettingsException,
+    Psycopg2VersionException,
 )
 
 
@@ -46,6 +48,12 @@ def main():
     if settings.DATABASE_ENGINE == "django.db.backends.postgresql":
         try:
             import psycopg2  # noqa
+
+            # Version of psycopg2 must not exceed 2.9 with django 2.2
+            # https://github.com/ansible-community/ara/issues/320
+            psycopg_version = psycopg2.__version__.split()[0]
+            if LooseVersion(psycopg_version) >= LooseVersion("2.9.0"):
+                raise Psycopg2VersionException(version=psycopg_version)
         except ImportError as e:
             raise MissingPsycopgException from e
 

--- a/ara/setup/exceptions.py
+++ b/ara/setup/exceptions.py
@@ -38,3 +38,10 @@ class MissingSettingsException(Exception):
     def __init__(self):
         exc = "The specified settings file does not exist or permissions are insufficient to read it."
         super().__init__(exc)
+
+
+class Psycopg2VersionException(Exception):
+    def __init__(self, version):
+        # https://github.com/ansible-community/ara/issues/320
+        exc = "The version of psycopg2 (%s) must be <2.9 due to an incompatibility with Django 2.2." % version
+        super().__init__(exc)


### PR DESCRIPTION
Add a friendlier exception when attempting to run with psycopg>=2.9
because 8e6932a39987ad542202859b58213741568c38cc is not sufficient.

Related to issue https://github.com/ansible-community/ara/issues/320.