### PR TITLE
cli: add --latest to 'ara host list'

### DIFF
--- a/doc/source/cli.rst
+++ b/doc/source/cli.rst
@@ -214,8 +214,11 @@ Examples:
 
 .. code-block:: bash
 
-    # List the latest 25 host results
+    # List the last 25 host reports
     ara host list --limit 25
+
+    # List only the latest playbook report for each host
+    ara host list --latest
 
     # List host records for a specific host name
     ara host list --name localhost


### PR DESCRIPTION
This mirrors the functionality provided by the hosts page of the
reporting interface.

By specifying --latest, only the latest playbook report will be
returned for each host.