### PR TITLE
container-images: bump to fedora35 and centos8-stream

### DIFF
--- a/contrib/container-images/README.rst
+++ b/contrib/container-images/README.rst
@@ -27,15 +27,15 @@ You will need to install `buildah <https://github.com/containers/buildah/blob/ma
 
 The different scripts to build container images are available in the git repository:
 
-- fedora33-distribution.sh_: Builds an image from Fedora 33 `distribution packages <https://koji.fedoraproject.org/koji/packageinfo?packageID=24394>`_
-- fedora33-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on Fedora 33
-- fedora33-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on Fedora 33
-- centos8-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on CentOS 8
+- fedora-distribution.sh_: Builds an image from Fedora 35 `distribution packages <https://koji.fedoraproject.org/koji/packageinfo?packageID=24394>`_
+- fedora-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on Fedora 35
+- fedora-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on Fedora 35
+- centos-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on CentOS 8 Stream
 
-.. _fedora33-distribution.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/fedora33-distribution.sh
-.. _fedora33-pypi.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/fedora33-pypi.sh
-.. _fedora33-source.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/fedora33-source.sh
-.. _centos8-pypi.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/centos8-pypi.sh
+.. _fedora-distribution.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/fedora-distribution.sh
+.. _fedora-pypi.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/fedora-pypi.sh
+.. _fedora-source.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/fedora-source.sh
+.. _centos-pypi.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/centos-pypi.sh
 
 The scripts have no arguments other than the ability to specify an optional name
 and tag:
@@ -44,7 +44,7 @@ and tag:
 
     $ git clone https://github.com/ansible-community/ara
     $ cd ara/contrib/container-images
-    $ ./fedora33-source.sh ara-api:latest
+    $ ./fedora-source.sh ara-api:latest
     # [...]
     Getting image source signatures
     Copying blob 59bbb69efd73 skipped: already exists

--- a/contrib/container-images/centos-pypi.sh
+++ b/contrib/container-images/centos-pypi.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -x
-# Builds an ARA API server container image using the latest PyPi packages on Fedora 33.
-build=$(buildah from fedora:33)
+# Builds an ARA API server container image using the latest PyPi packages on CentOS 8.
+build=$(buildah from quay.io/centos/centos:stream8)
 
 # Get all updates, install pip, database backends and gunicorn application server
 # This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.
 # Note: We use the packaged versions of psycopg2 and mysql python libraries so
 #       we don't need to install development libraries before installing them from PyPi.
-buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-psycopg2 python3-mysql python3-gunicorn && dnf clean all"
+buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y epel-release && dnf install -y which python3-pip python3-gunicorn python3-psycopg2 python3-mysql && dnf clean all"
 
 # Install ara from source with API server extras for dependencies (django & django-rest-framework)
 buildah run "${build}" -- /bin/bash -c "pip3 install ara[server]"

--- a/contrib/container-images/fedora-distribution.sh
+++ b/contrib/container-images/fedora-distribution.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
-# Builds an ARA API server container image from Fedora 33 distribution packages.
-build=$(buildah from fedora:33)
+# Builds an ARA API server container image from Fedora 35 distribution packages.
+build=$(buildah from quay.io/fedora/fedora:35)
 
 # Get all updates, install the ARA API server, database backends and gunicorn application server
 # This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.

--- a/contrib/container-images/fedora-pypi.sh
+++ b/contrib/container-images/fedora-pypi.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -x
-# Builds an ARA API server container image using the latest PyPi packages on CentOS 8.
-build=$(buildah from centos:8)
+# Builds an ARA API server container image using the latest PyPi packages on Fedora 35.
+build=$(buildah from quay.io/fedora/fedora:35)
 
 # Get all updates, install pip, database backends and gunicorn application server
 # This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.
 # Note: We use the packaged versions of psycopg2 and mysql python libraries so
 #       we don't need to install development libraries before installing them from PyPi.
-buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y epel-release && dnf install -y which python3-pip python3-gunicorn python3-psycopg2 python3-mysql && dnf clean all"
+buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-psycopg2 python3-mysql python3-gunicorn && dnf clean all"
 
 # Install ara from source with API server extras for dependencies (django & django-rest-framework)
 buildah run "${build}" -- /bin/bash -c "pip3 install ara[server]"

--- a/contrib/container-images/fedora-source.sh
+++ b/contrib/container-images/fedora-source.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -x
-# Builds an ARA API server container image from checked out source on Fedora 33.
+# Builds an ARA API server container image from checked out source on Fedora 35.
 # Figure out source directory relative to the contrib/container-images directory
 SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 SOURCE_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd -P)
@@ -10,7 +10,7 @@ python3 setup.py sdist
 sdist=$(ls dist/ara-*.tar.gz)
 popd
 
-build=$(buildah from fedora:33)
+build=$(buildah from quay.io/fedora/fedora:35)
 
 # Get all updates, install pip, database backends and gunicorn application server
 # This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.

--- a/tests/with_container_images.yaml
+++ b/tests/with_container_images.yaml
@@ -25,17 +25,17 @@
       # These are in chronological order of release so that we don't end up
       # running SQL migrations backwards during the tests.
       - name: localhost/ara-api
-        tag: fedora33-source-latest
-        script: fedora33-source.sh
+        tag: fedora35-source-latest
+        script: fedora-source.sh
       - name: localhost/ara-api
-        tag: fedora33-pypi-latest
-        script: fedora33-pypi.sh
+        tag: fedora35-pypi-latest
+        script: fedora-pypi.sh
       - name: localhost/ara-api
-        tag: centos8-pypi-latest
-        script: centos8-pypi.sh
+        tag: centos8-stream-pypi-latest
+        script: centos-pypi.sh
       - name: localhost/ara-api
-        tag: fedora33-distribution-latest
-        script: fedora33-distribution.sh
+        tag: fedora35-distribution-latest
+        script: fedora-distribution.sh
   tasks:
     - name: Install git, buildah and podman
       become: yes


### PR DESCRIPTION
This updates the scripts to use fedora35 and centos8-stream as base
images.