### PR TITLE
Add a localhost_to_hostname toggle in the ansible callback

### DIFF
--- a/tests/basic.yaml
+++ b/tests/basic.yaml
@@ -161,6 +161,8 @@
           command: "ansible-playbook -vvv {{ _test_root }}/smoke.yaml"
 
         - name: Run lookup integration tests
+          environment:
+            ARA_LOCALHOST_AS_HOSTNAME: "{{ ara_localhost_as_hostname | default(true) }}"
           command: "ansible-playbook -vvv {{ _test_root }}/lookups.yaml"
 
         - name: Run delegate_to integration tests

--- a/tests/integration/lookups.yaml
+++ b/tests/integration/lookups.yaml
@@ -17,6 +17,7 @@
         playbook: "{{ lookup('ara_api', '/api/v1/playbooks/' + playbook_id) }}"
         tasks: "{{ lookup('ara_api', '/api/v1/tasks?playbook=' + playbook_id) }}"
         results: "{{ lookup('ara_api', '/api/v1/results?playbook=' + playbook_id) }}"
+        hosts: "{{ lookup('ara_api', '/api/v1/hosts?playbook=' + playbook_id) }}"
 
     - name: Assert playbook properties
       assert:
@@ -26,6 +27,34 @@
           - playbook.ansible_version == ansible_version.full
           - playbook_dir in playbook.path
           - "'tests/integration/lookups.yaml' in playbook.path"
+
+    # TODO: Validate when set from configuration file too
+    - name: Validate hostname when localhost_as_hostname is enabled
+      vars:
+        _localhost_as_hostname: "{{ lookup('env', 'ARA_LOCALHOST_AS_HOSTNAME') | default(false) }}"
+      assert:
+        that:
+          - hosts['results'][0]['name'] != inventory_hostname
+          - hosts['results'][0]['name'] != 'localhost'
+          - inventory_hostname == 'localhost'
+        success_msg: "inventory_hostname '{{ inventory_hostname }}' != {{ hosts['results'][0]['name'] }}"
+        fail_msg: |
+          localhost_as_hostname is enabled but the inventory hostname is still localhost...
+          It should be the hostname of the controller.
+      when: _localhost_as_hostname | bool
+
+    - name: Validate hostname when localhost_as_hostname is not enabled
+      vars:
+        _localhost_as_hostname: "{{ lookup('env', 'ARA_LOCALHOST_AS_HOSTNAME') | default(false) }}"
+      assert:
+        that:
+          - inventory_hostname == 'localhost'
+          - hosts['results'][0]['name'] == inventory_hostname
+        success_msg: "inventory_hostname {{ inventory_hostname }} == {{ hosts['results'][0]['name'] }}"
+        fail_msg: |
+          localhost_as_hostname isn't enabled
+          The inventory_hostname is localhost but the host is not localhost (???)
+      when: not _localhost_as_hostname | bool
 
     #####
     # Examples taken from docs on Ansible plugins and use cases


### PR DESCRIPTION
In use cases where playbooks are run against localhost, it might be
useful to record results under the fqdn of the host instead in order to
differentiate task results belonging to different hosts.

TODO:
- integration tests
- docs