### PR TITLE
zuul: Add a post job to build and publish container images

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -47,6 +47,38 @@
     run: tests/with_container_images.yaml
 
 - job:
+    name: ara-container-images-dockerhub
+    parent: ara-integration-base
+    nodeset: fedora-latest-1vcpu
+    description: |
+      Builds ARA API container images with buildah and briefly tests them with podman.
+      The resulting images are pushed to docker.io/recordsansible/ara-api if successful.
+    pre-run: tests/with_container_images.yaml
+    run: tests/zuul_publish_container_images.yaml
+    vars:
+      destination_repository: docker.io/recordsansible/ara-api
+    secrets:
+      - name: ara_registry_credentials
+        secret: ara_dockerhub_credentials
+        pass-to-parent: true
+
+- job:
+    name: ara-container-images-quayio
+    parent: ara-integration-base
+    nodeset: fedora-latest-1vcpu
+    description: |
+      Builds ARA API container images with buildah and briefly tests them with podman.
+      The resulting images are pushed to quay.io/recordsansible/ara-api if successful.
+    pre-run: tests/with_container_images.yaml
+    run: tests/zuul_publish_container_images.yaml
+    vars:
+      destination_repository: quay.io/recordsansible/ara-api
+    secrets:
+      - name: ara_registry_credentials
+        secret: ara_quayio_credentials
+        pass-to-parent: true
+
+- job:
     name: ara-ansible-integration-base
     parent: ara-integration-base
     nodeset: ara-basic-nodeset

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -24,3 +24,8 @@
         - ara-basic-ansible-base-2.10
         - ara-basic-ansible-2.9
         - ara-container-images
+    post:
+      jobs:
+        - ara-container-images-dockerhub
+        - ara-container-images-quayio
+

--- a/.zuul.d/secrets.yaml
+++ b/.zuul.d/secrets.yaml
@@ -1,0 +1,33 @@
+---
+- secret:
+    name: ara_dockerhub_credentials
+    data:
+      username: arainfra
+      password: !encrypted/pkcs1-oaep
+        - NbTCli9XSy2wwsoa2KA47yx6cnSHGUkR4PpmFlEdEdXM1myl80K9vCpZkxq3GwYexNawX
+          alVHroylQ/pbryH8xBRlRIGVniBs98q0Md6Bm3mnIx9qFDXjq8bSWu9FOcIXJBkj6d30g
+          GVTDrYi7MI6RbOd0Mp2O3opR3eMBwfhWVmniHjI997pjvyRrQ2T0oAeS5Ac0GARvVYHTq
+          I8x7wFOiOf8DfilS6CF499n5SSwcI4/N72VPyf24xuYh6b3umwwt8klvGRdsyb3B3sf/3
+          YySGTcCs9Dc7m/N3OzXVr8TTOXnN28+B7f+03JOYu9vesz1mU91OPKh4AhvYdJWeicTjg
+          YnW5ousc7M01R4XYSymzIEaXqm+WQoTEEXhW7oKWXO61sbTm3I5ze4sy48GclFYk7WqBm
+          so8y7ug+bbZ7+ResOGJhaXGNH9m0FzQEaWPb25g7j9Zr1l/RXYcWXHkHrbp5ZCMB8R4p+
+          Sweye1Rg4vjSpTc8MHQ0oXC0WEZMRARQW3WGZxYwJhG034FKt/fzSjYMqnsy82Frw8+xT
+          Ahb+vJzNAXLesHdc6hCmwXWYxj2I2ShVg6hYWTEtkkEKvr4+7MSuoRPTJns00As8t396j
+          V4Icm4njJtphsBpUI7OPrCT88x4m9zBKCU0tsVsCs16cX9Fr88omMjtOPDlIYU=
+
+- secret:
+    name: ara_quayio_credentials
+    data:
+      username: "recordsansible+zuul_ansible"
+      password: !encrypted/pkcs1-oaep
+        - NNKLY9KhlXZ0kBXJuqGJxYtFB3uBx54sz2ufKGXIZIouN3wRldg+5gCEJKzFsrMbBHZUR
+          0jQIABkWBUrOCy+QCB4xpLlQ/wmJMcX3FylvTk0s+vMEGrQjRjJoppidRS1tVO5B46LX2
+          k2yn63o1hPbSp5plwBk6m4s5AgBRnveLy03vKeEoqpRFBr5xegiiK0Fug5twt3KAaoetS
+          g6M0DeMEu2ASh7kZBvVL/fag9w5OmBpdq5lMTctalj2/Ll31YXBicqQ2z2sQmZEtCa3MA
+          anlfhg2DkApKdgW1kaCK5BBy2F4RQ1IzlbNWV9UqZ1XAHSnN+LOnqDEBocygQQizRbA/I
+          ZLh8snGnnCe/i8OF4tk3tn3YmUnE6HkI6vW9XIWPRTV8n0YvbEi00R6yWK7GHC4dsBlWQ
+          1uvd4er7xEXWjJaPbwkqKHn5ZcTlKIWNTwIvVHm07vAi4/GJqvZWzxrYlqxs5is9ZszT/
+          0DNXr/FcE8utGibMhvVeZ3N9WDeQObXE+IBt/thrTktFxvCSYhtTeaVgWYA4KWXshOO1J
+          4BnI63gtQpWmeYNPCH+kBpTFcT6GRGmXtyWfFXDLee48U1rMdeagI1OTwHQTquJ5VR4WW
+          IGX7faqNnK5KHTaYa7ebI0C+9FjRAjd3fdLNtYyLXV/JUIIN/klN9jJbtEZ6Rk=
+

--- a/tests/zuul_publish_container_images.yaml
+++ b/tests/zuul_publish_container_images.yaml
@@ -23,22 +23,22 @@
     images:
       # These images are meant to be provided by the "with_container_images.yaml" playbook
       - name: localhost/ara-api
-        tag: fedora33-source-latest
+        tag: fedora35-source-latest
       - name: localhost/ara-api
-        tag: fedora33-pypi-latest
+        tag: fedora35-pypi-latest
       - name: localhost/ara-api
         tag: centos8-pypi-latest
       - name: localhost/ara-api
-        tag: fedora33-distribution-latest
+        tag: fedora35-distribution-latest
   tasks:
     - name: Tag images with buildah
       command: |
         buildah tag {{ item.name }}:{{ item.tag }} {{ destination }}:{{ item.tag }}
       loop: "{{ images }}"
 
-    - name: Tag latest from fedora33-source-latest
+    - name: Tag latest from fedora35-source-latest
       command: |
-        buildah tag {{ destination }}:fedora33-source-latest {{ destination }}:latest
+        buildah tag {{ destination }}:fedora35-source-latest {{ destination }}:latest
 
     - name: Push latest
       command: |


### PR DESCRIPTION
We used to do this before migrating to this instance of Zuul, see
3053583ddb6e088fb59a9fa8508438a46561d257.

This adds the jobs back in such that container images will be built,
tested and published to dockerhub and quay.io every time a new PR is
merged.