### PR TITLE
zuul: escalate privileges when publishing container images

### DIFF
--- a/tests/zuul_publish_container_images.yaml
+++ b/tests/zuul_publish_container_images.yaml
@@ -18,6 +18,7 @@
 - name: Publish container images
   hosts: all
   gather_facts: yes
+  become: yes
   vars:
     destination: "{{ destination_repository | default('docker.io/recordsansible/ara-api') }}"
     images:


### PR DESCRIPTION
In f1de47778311c81fc0c8f7f8c72edc591c2eebb6 we added a workaround for an
issue by escalating privileges when building and testing images.

We need to escalate when publishing as well otherwise the unprivileged
user won't see the images that were built prior.