### PR TITLE
zuul: image name is now centos8-stream-pypi-latest

### DIFF
--- a/tests/zuul_publish_container_images.yaml
+++ b/tests/zuul_publish_container_images.yaml
@@ -28,7 +28,7 @@
       - name: localhost/ara-api
         tag: fedora35-pypi-latest
       - name: localhost/ara-api
-        tag: centos8-pypi-latest
+        tag: centos8-stream-pypi-latest
       - name: localhost/ara-api
         tag: fedora35-distribution-latest
   tasks:


### PR DESCRIPTION
When updating from centos8 to centos8-stream we renamed the image and
forgot to use the right name here.