### PR TITLE
requirements: update django to 3.2 LTS

### DIFF
--- a/ara/server/__main__.py
+++ b/ara/server/__main__.py
@@ -18,7 +18,6 @@
 
 import os
 import sys
-from distutils.version import LooseVersion
 
 from django.conf import settings
 
@@ -27,7 +26,6 @@ from ara.setup.exceptions import (
     MissingMysqlclientException,
     MissingPsycopgException,
     MissingSettingsException,
-    Psycopg2VersionException,
 )
 
 
@@ -48,12 +46,6 @@ def main():
     if settings.DATABASE_ENGINE == "django.db.backends.postgresql":
         try:
             import psycopg2  # noqa
-
-            # Version of psycopg2 must not exceed 2.9 with django 2.2
-            # https://github.com/ansible-community/ara/issues/320
-            psycopg_version = psycopg2.__version__.split()[0]
-            if LooseVersion(psycopg_version) >= LooseVersion("2.9.0"):
-                raise Psycopg2VersionException(version=psycopg_version)
         except ImportError as e:
             raise MissingPsycopgException from e
 

--- a/ara/setup/exceptions.py
+++ b/ara/setup/exceptions.py
@@ -38,10 +38,3 @@ class MissingSettingsException(Exception):
     def __init__(self):
         exc = "The specified settings file does not exist or permissions are insufficient to read it."
         super().__init__(exc)
-
-
-class Psycopg2VersionException(Exception):
-    def __init__(self, version):
-        # https://github.com/ansible-community/ara/issues/320
-        exc = "The version of psycopg2 (%s) must be <2.9 due to an incompatibility with Django 2.2." % version
-        super().__init__(exc)

--- a/doc/source/api-configuration.rst
+++ b/doc/source/api-configuration.rst
@@ -8,7 +8,7 @@ environments (*such as dev, staging, prod*) and allows you to customize the
 configuration with files, environment variables or a combination of both.
 
 The API is a Django application that leverages django-rest-framework.
-Both `Django <https://docs.djangoproject.com/en/2.2/ref/settings/>`_ and
+Both `Django <https://docs.djangoproject.com/en/3.2/ref/settings/>`_ and
 `django-rest-framework <https://www.django-rest-framework.org/api-guide/settings/>`_
 have extensive configuration options which are not necessarily exposed or made
 customizable by ARA for the sake of simplicity.
@@ -79,19 +79,19 @@ For more details, click on the configuration parameters.
 
 .. _CORS_ORIGIN_WHITELIST: https://github.com/adamchainz/django-cors-headers#cors_origin_whitelist
 .. _CORS_ORIGIN_REGEX_WHITELIST: https://github.com/adamchainz/django-cors-headers#cors_origin_regex_whitelist
-.. _CSRF_TRUSTED_ORIGINS: https://docs.djangoproject.com/en/2.2/ref/settings/#csrf-trusted-origins
-.. _ALLOWED_HOSTS: https://docs.djangoproject.com/en/2.2/ref/settings/#allowed-hosts
-.. _DEBUG: https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-DEBUG
-.. _SECRET_KEY: https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-SECRET_KEY
-.. _TIME_ZONE: https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-TIME_ZONE
-.. _ENGINE: https://docs.djangoproject.com/en/2.2/ref/settings/#engine
-.. _NAME: https://docs.djangoproject.com/en/2.2/ref/settings/#name
-.. _USER: https://docs.djangoproject.com/en/2.2/ref/settings/#user
-.. _PASSWORD: https://docs.djangoproject.com/en/2.2/ref/settings/#password
-.. _HOST: https://docs.djangoproject.com/en/2.2/ref/settings/#host
-.. _PORT: https://docs.djangoproject.com/en/2.2/ref/settings/#port
-.. _CONN_MAX_AGE: https://docs.djangoproject.com/en/2.2/ref/settings/#conn-max-age
-.. _OPTIONS: https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-OPTIONS
+.. _CSRF_TRUSTED_ORIGINS: https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins
+.. _ALLOWED_HOSTS: https://docs.djangoproject.com/en/3.2/ref/settings/#allowed-hosts
+.. _DEBUG: https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-DEBUG
+.. _SECRET_KEY: https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-SECRET_KEY
+.. _TIME_ZONE: https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-TIME_ZONE
+.. _ENGINE: https://docs.djangoproject.com/en/3.2/ref/settings/#engine
+.. _NAME: https://docs.djangoproject.com/en/3.2/ref/settings/#name
+.. _USER: https://docs.djangoproject.com/en/3.2/ref/settings/#user
+.. _PASSWORD: https://docs.djangoproject.com/en/3.2/ref/settings/#password
+.. _HOST: https://docs.djangoproject.com/en/3.2/ref/settings/#host
+.. _PORT: https://docs.djangoproject.com/en/3.2/ref/settings/#port
+.. _CONN_MAX_AGE: https://docs.djangoproject.com/en/3.2/ref/settings/#conn-max-age
+.. _OPTIONS: https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-OPTIONS
 
 Configuration variables
 -----------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ ara.cli =
 
 [extras]
 server=
-    Django>=2.1.5,<3.0
+    Django>=3.2,<3.3
     djangorestframework>=3.9.1
     django-cors-headers
     django-filter
@@ -74,9 +74,7 @@ server=
     whitenoise
     pygments
 postgresql=
-    # Pin psycopg2 until we upgrade to django 3.2 LTS
-    # https://github.com/ansible-community/ara/issues/320
-    psycopg2<2.9
+    psycopg2
 
 [build_sphinx]
 source-dir = doc/source


### PR DESCRIPTION
We've been recommending django 2.2 LTS and now that 3.2 has been out for
almost a year, we should bump the requirement.