### PR TITLE
logging: fix no logs when ARA callback set

### DIFF
--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -66,7 +66,7 @@ LOGGING = settings.get(
         },
         "loggers": {"ara": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": 0}},
     },
-)
+).to_dict()
 
 if "root" in LOGGING:
     print('[ara] "root" key not allowed in "LOGGING" configuration. Removing...')

--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -48,6 +48,8 @@ BASE_DIR = settings.get("BASE_DIR", BASE_DIR)
 DEBUG = settings.get("DEBUG", False, "@bool")
 
 LOG_LEVEL = settings.get("LOG_LEVEL", "INFO")
+# default logger updated cf issue https://github.com/ansible-community/ara/issues/228
+# and PR https://github.com/ansible-community/ara/pull/367
 LOGGING = settings.get(
     "LOGGING",
     {

--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -48,38 +48,31 @@ BASE_DIR = settings.get("BASE_DIR", BASE_DIR)
 DEBUG = settings.get("DEBUG", False, "@bool")
 
 LOG_LEVEL = settings.get("LOG_LEVEL", "INFO")
-# fmt: off
-LOGGING = settings.get("LOGGING", {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "normal": {
-            "format": "%(asctime)s %(levelname)s %(name)s: %(message)s"
-        }
+LOGGING = settings.get(
+    "LOGGING",
+    {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "normal": {"format": "%(asctime)s %(levelname)s %(name)s: %(message)s"}
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "normal",
+                "level": LOG_LEVEL,
+                "stream": "ext://sys.stdout",
+            }
+        },
+        "loggers": {
+            "ara": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": 0}
+        },
     },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "normal",
-            "level": LOG_LEVEL,
-            "stream": "ext://sys.stdout",
-        }
-    },
-    "loggers": {
-        "ara": {
-            "handlers": ["console"],
-            "level": LOG_LEVEL,
-            "propagate": 0
-        }
-    },
-    "root": {
-        "handlers": ["console"],
-        "level": LOG_LEVEL
-    },
-})
-# fmt: on
+)
 
-print(LOGGING)
+if "root" in LOGGING:
+    print('[ara] "root" key not allowed in "LOGGING" configuration. Removing...')
+    del LOGGING["root"]
 
 # Django built-in server and npm development server
 ALLOWED_HOSTS = settings.get("ALLOWED_HOSTS", ["::1", "127.0.0.1", "localhost"])

--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -53,9 +53,7 @@ LOGGING = settings.get(
     {
         "version": 1,
         "disable_existing_loggers": False,
-        "formatters": {
-            "normal": {"format": "%(asctime)s %(levelname)s %(name)s: %(message)s"}
-        },
+        "formatters": {"normal": {"format": "%(asctime)s %(levelname)s %(name)s: %(message)s"}},
         "handlers": {
             "console": {
                 "class": "logging.StreamHandler",
@@ -64,9 +62,7 @@ LOGGING = settings.get(
                 "stream": "ext://sys.stdout",
             }
         },
-        "loggers": {
-            "ara": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": 0}
-        },
+        "loggers": {"ara": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": 0}},
     },
 )
 
@@ -76,9 +72,7 @@ if "root" in LOGGING:
 
 # Django built-in server and npm development server
 ALLOWED_HOSTS = settings.get("ALLOWED_HOSTS", ["::1", "127.0.0.1", "localhost"])
-CORS_ORIGIN_WHITELIST = settings.get(
-    "CORS_ORIGIN_WHITELIST", ["http://127.0.0.1:8000", "http://localhost:3000"]
-)
+CORS_ORIGIN_WHITELIST = settings.get("CORS_ORIGIN_WHITELIST", ["http://127.0.0.1:8000", "http://localhost:3000"])
 CORS_ORIGIN_REGEX_WHITELIST = settings.get("CORS_ORIGIN_REGEX_WHITELIST", [])
 CORS_ORIGIN_ALLOW_ALL = settings.get("CORS_ORIGIN_ALLOW_ALL", False)
 
@@ -112,9 +106,7 @@ DISTRIBUTED_SQLITE_ROOT = settings.get("DISTRIBUTED_SQLITE_ROOT", "/var/www/logs
 
 if DISTRIBUTED_SQLITE:
     WSGI_APPLICATION = "ara.server.wsgi.distributed_sqlite"
-    DATABASE_ENGINE = settings.get(
-        "DATABASE_ENGINE", "ara.server.db.backends.distributed_sqlite"
-    )
+    DATABASE_ENGINE = settings.get("DATABASE_ENGINE", "ara.server.db.backends.distributed_sqlite")
 else:
     WSGI_APPLICATION = "ara.server.wsgi.application"
     DATABASE_ENGINE = settings.get("DATABASE_ENGINE", "django.db.backends.sqlite3")
@@ -207,9 +199,7 @@ TEMPLATES = [
 ]
 
 AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
-    },
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},

--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -49,10 +49,14 @@ DEBUG = settings.get("DEBUG", False, "@bool")
 
 LOG_LEVEL = settings.get("LOG_LEVEL", "INFO")
 # fmt: off
-LOGGING = {
+LOGGING = settings.get("LOGGING", {
     "version": 1,
     "disable_existing_loggers": False,
-    "formatters": {"normal": {"format": "%(asctime)s %(levelname)s %(name)s: %(message)s"}},
+    "formatters": {
+        "normal": {
+            "format": "%(asctime)s %(levelname)s %(name)s: %(message)s"
+        }
+    },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
@@ -72,13 +76,16 @@ LOGGING = {
         "handlers": ["console"],
         "level": LOG_LEVEL
     },
-}
+})
 # fmt: on
 
+print(LOGGING)
 
 # Django built-in server and npm development server
 ALLOWED_HOSTS = settings.get("ALLOWED_HOSTS", ["::1", "127.0.0.1", "localhost"])
-CORS_ORIGIN_WHITELIST = settings.get("CORS_ORIGIN_WHITELIST", ["http://127.0.0.1:8000", "http://localhost:3000"])
+CORS_ORIGIN_WHITELIST = settings.get(
+    "CORS_ORIGIN_WHITELIST", ["http://127.0.0.1:8000", "http://localhost:3000"]
+)
 CORS_ORIGIN_REGEX_WHITELIST = settings.get("CORS_ORIGIN_REGEX_WHITELIST", [])
 CORS_ORIGIN_ALLOW_ALL = settings.get("CORS_ORIGIN_ALLOW_ALL", False)
 
@@ -112,7 +119,9 @@ DISTRIBUTED_SQLITE_ROOT = settings.get("DISTRIBUTED_SQLITE_ROOT", "/var/www/logs
 
 if DISTRIBUTED_SQLITE:
     WSGI_APPLICATION = "ara.server.wsgi.distributed_sqlite"
-    DATABASE_ENGINE = settings.get("DATABASE_ENGINE", "ara.server.db.backends.distributed_sqlite")
+    DATABASE_ENGINE = settings.get(
+        "DATABASE_ENGINE", "ara.server.db.backends.distributed_sqlite"
+    )
 else:
     WSGI_APPLICATION = "ara.server.wsgi.application"
     DATABASE_ENGINE = settings.get("DATABASE_ENGINE", "django.db.backends.sqlite3")
@@ -205,7 +214,9 @@ TEMPLATES = [
 ]
 
 AUTH_PASSWORD_VALIDATORS = [
-    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+    },
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},

--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -69,7 +69,11 @@ LOGGING = settings.get(
 ).to_dict()
 
 if "root" in LOGGING:
-    print('[ara] "root" key not allowed in "LOGGING" configuration. Removing...')
+    print(
+        "[ara] Server's LOGGING configuration has a 'root' logger which is deprecated after version 1.5.8 "
+        "due to conflicts. Please update your settings.yaml or generate a new one by "
+        "removing it from ara's configuration folder"
+    )
     del LOGGING["root"]
 
 # Django built-in server and npm development server

--- a/doc/source/api-configuration.rst
+++ b/doc/source/api-configuration.rst
@@ -463,23 +463,20 @@ ARA_LOGGING
     LOGGING:
         disable_existing_loggers: false
         formatters:
-        normal:
-            format: '%(asctime)s %(levelname)s %(name)s: %(message)s'
+            normal:
+                format: '%(asctime)s %(levelname)s %(name)s: %(message)s'
         handlers:
-        console:
-            class: logging.StreamHandler
-            formatter: normal
-            level: INFO
-            stream: ext://sys.stdout
+            console:
+                class: logging.StreamHandler
+                formatter: normal
+                level: INFO
+                stream: ext://sys.stdout
         loggers:
-        ara:
-            handlers:
-            - console
-            level: INFO
-            propagate: 0
-        root:
-        handlers:
-        - console
+            ara:
+                handlers:
+                - console
+                level: INFO
+                propagate: 0
         level: INFO
         version: 1
 


### PR DESCRIPTION
Problem:
- Ansible log file contains only warning when ARA's callback plugin is set. 
- User LOGGING configuration was not used 

Context:
As mentioned in issue #228, `Django` logging variable was not defined correctly. It was missing a function call to gather user's logging configuration from `dynaconf` like so:

```python
LOGGING = settings.get("LOGGING", ...)
```

Also, due to default LOGGING configuration, when ARA's ansible callback plugin is set, and `log_path` is set in `ansible.cfg`, this result in fewer logs inside ansible log file. Mostly warnings. It happening because ansible logging system uses the `root` configuration to generate its `FileHandler` logger. cf: https://github.com/ansible/ansible/blob/6f445ca6e5c9c8b85ccc5062e00508c69ca26fde/lib/ansible/utils/display.py#L166-L178

As such, by redefining the root logger in `settings.yaml` by default when no user configuration is passed, results to dumping ansible logs. The explanation outside of the ansible's logger, is due to `Django` configuration injector  https://docs.djangoproject.com/en/4.0/topics/settings/ . It will take the new LOGGING field as default logging configuration and override existing root logger.

Solution:
- Get user's LOGGING configuration by retrieving it from `dynaconf`
- Update default LOGGING configuration by removing root key
- Check if user defined a "root" key inside its configuration and, if so, removing it (and print a warning)