### PR TITLE
fix: remove deprecation warnings

### DIFF
--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -35,9 +35,9 @@ DEFAULT_SETTINGS = os.path.join(BASE_DIR, "settings.yaml")
 
 settings = LazySettings(
     environments=True,
-    GLOBAL_ENV_FOR_DYNACONF="ARA",
+    ENVVAR_PREFIX_FOR_DYNACONF="ARA",
     ENVVAR_FOR_DYNACONF="ARA_SETTINGS",
-    SETTINGS_MODULE_FOR_DYNACONF=DEFAULT_SETTINGS,
+    SETTINGS_FILE_FOR_DYNACONF=DEFAULT_SETTINGS,
 )
 
 # reread BASE_DIR since it might have gotten changed in the config file.

--- a/ara/setup/env.py
+++ b/ara/setup/env.py
@@ -18,7 +18,7 @@
 from __future__ import print_function
 
 import os
-from distutils.sysconfig import get_python_lib
+from sysconfig import get_path
 
 from . import action_plugins, callback_plugins, lookup_plugins
 
@@ -36,7 +36,7 @@ if "VIRTUAL_ENV" in os.environ:
     failure to find ara module.
     """
     # inspired by https://stackoverflow.com/a/122340/99834
-    lib = get_python_lib()
+    lib = get_path("purelib")
     if "PYTHONPATH" in os.environ:
         python_paths = os.environ["PYTHONPATH"].split(os.pathsep)
     else:


### PR DESCRIPTION
- Dynaconf updated their args for parsing configuration (ENV, file, etc). Old arguments are now deprecated.
- `distutil.sysconfig` is deprecated and will be removed in `v3.12` [news](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated)

closes #363
closes #344 