### PR TITLE
chore: change configuration keys naming convention for setup.cfg python3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = ara
 summary = ARA Records Ansible
-description-file =
+description_file =
     README.rst
 author = OpenStack Community
-author-email = openstack-discuss@lists.openstack.org
-home-page = https://github.com/ansible-community/ara
+author_email = openstack-discuss@lists.openstack.org
+home_page = https://github.com/ansible-community/ara
 classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators


### PR DESCRIPTION
closes #338