### PR TITLE
Pin dynaconf to <3.0.0 when using python3.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,9 @@ server=
     django-filter
     django-health-check
     # dynaconf 3.1.3 had a regression https://github.com/ansible-community/ara/issues/212
-    dynaconf[yaml]>=3.0.0,!=3.1.3,<4.0.0
+    # dynaconf dropped support for py35 at version 3.0.0: https://github.com/ansible-community/ara/issues/370
+    dynaconf[yaml]>=3.0.0,!=3.1.3,<4.0.0;python_version>='3.6'
+    dynaconf[yaml]<3.0.0;python_version<'3.6'
     tzlocal<3.0
     whitenoise
     pygments


### PR DESCRIPTION
dynaconf 3.0.0 dropped support for python3.5 by introducing f-strings
which landed in python3.6 and resulted in ara not working under py35.

Let's pin it in order to do a last release compatible with py35 and it
can be removed later.

Closes: https://github.com/ansible-community/ara/issues/370