### PR TITLE
ui: Move task tags to their own column

### DIFF
--- a/ara/ui/templates/partials/host_results.html
+++ b/ara/ui/templates/partials/host_results.html
@@ -117,6 +117,7 @@
               <thead>
                 <tr style="height:50px;">
                   <th class="text-center">Details</th>
+                  <th class="text-center">Tags</th>
                   <th class="text-center">Status</th>
                   <th>Host</th>
                   <th>Action</th>
@@ -138,6 +139,11 @@
                       </svg>
                     </a>
                   </td>
+                  <td>
+                    <span class="badge badge-pill badge-secondary" class="btn btn-secondary" data-toggle="tooltip"  data-placement="right" data-html="true" title="{% include 'partials/tags_list.html' with tags=result.task.tags %}">
+                      {{ result.task.tags | length }} tag{{ result.task.tags | pluralize }}
+                    </span>
+                  </td>
                   <td class="text-center">
                     {% if not static_generation %}
                       {% url 'ui:host' host.id as host_url %}
@@ -145,13 +151,6 @@
                     {% else %}
                       {% include "partials/result_status_icon.html" with status=result.status %}
                     {% endif %}
-                    {% if result.task.tags %}
-                      <span class="badge badge-pill badge-secondary" class="btn btn-secondary" data-toggle="tooltip"  data-placement="right" data-html="true" title="{% include 'partials/tags_list.html' with tags=result.task.tags %}">
-                    {% else %}
-                      <span class="badge badge-pill badge-secondary invisible" class="btn btn-secondary">
-                    {% endif %}
-                      {{ result.task.tags | length }} tag{{ result.task.tags | pluralize }}
-                      </span>
                   </td>
                   <td>
                     {{ host.name }}

--- a/ara/ui/templates/partials/playbook_results.html
+++ b/ara/ui/templates/partials/playbook_results.html
@@ -100,6 +100,7 @@
               <thead>
                 <tr style="height:50px;">
                   <th class="text-center">Details</th>
+                  <th class="text-center">Tags</th>
                   <th class="text-center">Status</th>
                   <th>Host</th>
                   <th>Action</th>
@@ -122,18 +123,16 @@
                     </a>
                   </td>
                   <td class="text-center">
+                    <span class="badge badge-pill badge-secondary" class="btn btn-secondary" data-toggle="tooltip"  data-placement="right" data-html="true" title="{% if result.task.tags %}{% include 'partials/tags_list.html' with tags=result.task.tags %}{% endif %}">
+                      {{ result.task.tags | length }}
+                    </span>
+                  </td>
+                  <td class="text-center">
                     {% if not static_generation %}
                       {% include "partials/result_status_icon.html" with status=result.status search_url=playbook_url %}
                     {% else %}
                       {% include "partials/result_status_icon.html" with status=result.status %}
                     {% endif %}
-                    {% if result.task.tags %}
-                      <span class="badge badge-pill badge-secondary btn btn-secondary" data-toggle="tooltip"  data-placement="right" data-html="true" title="{% include 'partials/tags_list.html' with tags=result.task.tags %}">
-                    {% else %}
-                      <span class="badge badge-pill badge-secondary invisible btn btn-secondary">
-                    {% endif %}
-                      {{ result.task.tags | length }} tag{{ result.task.tags | pluralize }}
-                      </span>
                   </td>
                   <td>
                     {% if not static_generation %}


### PR DESCRIPTION
They don't take up too much width, let's put them there and include just
the number.