### PR TITLE
container-images: tag latest from pypi-latest instead of source-latest

### DIFF
--- a/tests/zuul_publish_container_images.yaml
+++ b/tests/zuul_publish_container_images.yaml
@@ -37,9 +37,9 @@
         buildah tag {{ item.name }}:{{ item.tag }} {{ destination }}:{{ item.tag }}
       loop: "{{ images }}"
 
-    - name: Tag latest from fedora35-source-latest
+    - name: Tag latest from fedora35-pypi-latest
       command: |
-        buildah tag {{ destination }}:fedora35-source-latest {{ destination }}:latest
+        buildah tag {{ destination }}:fedora35-pypi-latest {{ destination }}:latest
 
     - name: Push latest
       command: |


### PR DESCRIPTION
source-latest means it is coming from the master branch which can be
disruptive, especially with larger changes coming.

Let's set latest to point to the latest pypi release which is more
stable instead.