### PR TITLE
fix: failed to parse timedelta over 24h

### DIFF
--- a/ara/cli/playbook.py
+++ b/ara/cli/playbook.py
@@ -530,7 +530,7 @@ class PlaybookMetrics(Lister):
                 "running": 0,
                 "completed": 0,
                 "unknown": 0,
-                "duration_total": "00:00:00.000000",
+                "duration_total": 0.0,
             }
 
             if args.aggregate == "path" and not args.long:
@@ -547,11 +547,17 @@ class PlaybookMetrics(Lister):
                     data[item][obj] += playbook["items"][obj]
 
                 if playbook["duration"] is not None:
+                    print(f'duration {playbook["duration"]} === duration total:{data[item]["duration_total"]}')
+                    print(
+                        f'duration {type(playbook["duration"])} === duration total:{type(data[item]["duration_total"])}'
+                    )
                     data[item]["duration_total"] = cli_utils.sum_timedelta(
                         playbook["duration"], data[item]["duration_total"]
                     )
 
-            data[item]["duration_avg"] = cli_utils.avg_timedelta(data[item]["duration_total"], data[item]["count"])
+            delta = timedelta(seconds=data[item]["duration_total"])
+            data[item]["duration_total"] = str(delta)
+            data[item]["duration_avg"] = cli_utils.avg_timedelta(delta, data[item]["count"])
 
         # fmt: off
         if args.long:

--- a/ara/cli/playbook.py
+++ b/ara/cli/playbook.py
@@ -547,10 +547,6 @@ class PlaybookMetrics(Lister):
                     data[item][obj] += playbook["items"][obj]
 
                 if playbook["duration"] is not None:
-                    print(f'duration {playbook["duration"]} === duration total:{data[item]["duration_total"]}')
-                    print(
-                        f'duration {type(playbook["duration"])} === duration total:{type(data[item]["duration_total"])}'
-                    )
                     data[item]["duration_total"] = cli_utils.sum_timedelta(
                         playbook["duration"], data[item]["duration_total"]
                     )

--- a/ara/cli/task.py
+++ b/ara/cli/task.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from datetime import timedelta
 import logging
 import os
 import sys
@@ -373,7 +374,7 @@ class TaskMetrics(Lister):
                 "running": 0,
                 "completed": 0,
                 "unknown": 0,
-                "duration_total": "00:00:00.000000",
+                "duration_total": 0.0,
             }
 
             if args.aggregate == "path" and not args.long:
@@ -393,7 +394,9 @@ class TaskMetrics(Lister):
                         task["duration"], data[item]["duration_total"]
                     )
 
-            data[item]["duration_avg"] = cli_utils.avg_timedelta(data[item]["duration_total"], data[item]["count"])
+            delta = timedelta(seconds=data[item]["duration_total"])
+            data[item]["duration_total"] = str(delta)
+            data[item]["duration_avg"] = cli_utils.avg_timedelta(delta, data[item]["count"])
 
         # fmt: off
         if args.long:

--- a/ara/cli/utils.py
+++ b/ara/cli/utils.py
@@ -30,33 +30,30 @@ def get_host(client, host_id):
     return host
 
 
-def parse_timedelta(string, pattern="%H:%M:%S.%f"):
+def parse_timedelta(duration: str, pattern: str = "%H:%M:%S.%f"):
     """Parses a timedelta string back into a timedelta object"""
-    parsed = datetime.strptime(string, pattern)
+    parsed = datetime.strptime(duration, pattern)
     # fmt: off
     return timedelta(
         hours=parsed.hour,
         minutes=parsed.minute,
         seconds=parsed.second,
         microseconds=parsed.microsecond
-    )
+    ).total_seconds()
     # fmt: on
 
 
-def sum_timedelta(first, second):
+def sum_timedelta(duration: str, total: float):
     """
     Returns the sum of two timedeltas as provided by the API, for example:
     00:00:02.031557 + 00:00:04.782581 = ?
     """
-    first = parse_timedelta(first)
-    second = parse_timedelta(second)
-    return str(first + second)
+    return parse_timedelta(duration) + total
 
 
-def avg_timedelta(timedelta, count):
+def avg_timedelta(delta: timedelta, count: int):
     """Returns an average timedelta based on the amount of occurrences"""
-    timedelta = parse_timedelta(timedelta)
-    return str(timedelta / count)
+    return str(delta / count)
 
 
 # Also see: ui.templatetags.truncatepath


### PR DESCRIPTION
Solution:
Instead of using plane time string, I simply used the total seconds for the whole loop.
I parse the playbook duration into `timedelta`, then transform it into seconds (which take the milliseconds as `float`).
At the, I'll transform the total elapsed seconds into a `timedelta` for display. 

closes  #364 