### PR TITLE
ui: Fix display of task tags when viewing host results

### DIFF
--- a/ara/ui/templates/partials/host_results.html
+++ b/ara/ui/templates/partials/host_results.html
@@ -139,9 +139,9 @@
                       </svg>
                     </a>
                   </td>
-                  <td>
-                    <span class="badge badge-pill badge-secondary" class="btn btn-secondary" data-toggle="tooltip"  data-placement="right" data-html="true" title="{% include 'partials/tags_list.html' with tags=result.task.tags %}">
-                      {{ result.task.tags | length }} tag{{ result.task.tags | pluralize }}
+                  <td class="text-center">
+                    <span class="badge badge-pill badge-secondary" class="btn btn-secondary" data-toggle="tooltip"  data-placement="right" data-html="true" title="{% if result.task.tags %}{% include 'partials/tags_list.html' with tags=result.task.tags %}{% endif %}">
+                      {{ result.task.tags | length }}
                     </span>
                   </td>
                   <td class="text-center">


### PR DESCRIPTION
They should be centered and display only the number.