### PR TITLE
Add support for configuring `HttpClient` TLS client certificate and CA

### DIFF
--- a/ara/clients/http.py
+++ b/ara/clients/http.py
@@ -14,11 +14,12 @@ CLIENT_VERSION = pbr.version.VersionInfo("ara").release_string()
 
 
 class HttpClient(object):
-    def __init__(self, endpoint="http://127.0.0.1:8000", auth=None, timeout=30, verify=True):
+    def __init__(self, endpoint="http://127.0.0.1:8000", auth=None, cert=None, timeout=30, verify=True):
         self.log = logging.getLogger(__name__)
 
         self.endpoint = endpoint.rstrip("/")
         self.auth = auth
+        self.cert = cert
         self.timeout = int(timeout)
         self.verify = verify
         self.headers = {
@@ -30,6 +31,8 @@ class HttpClient(object):
         self.http.headers.update(self.headers)
         if self.auth is not None:
             self.http.auth = self.auth
+        if self.cert is not None:
+            self.http.cert = self.cert
         self.http.verify = self.verify
 
     def _request(self, method, url, **payload):
@@ -59,13 +62,16 @@ class HttpClient(object):
 
 
 class AraHttpClient(object):
-    def __init__(self, endpoint="http://127.0.0.1:8000", auth=None, timeout=30, verify=True):
+    def __init__(self, endpoint="http://127.0.0.1:8000", auth=None, cert=None, timeout=30, verify=True):
         self.log = logging.getLogger(__name__)
         self.endpoint = endpoint
         self.auth = auth
+        self.cert = cert
         self.timeout = int(timeout)
         self.verify = verify
-        self.client = HttpClient(endpoint=self.endpoint, timeout=self.timeout, auth=self.auth, verify=self.verify)
+        self.client = HttpClient(
+            endpoint=self.endpoint, timeout=self.timeout, auth=self.auth, cert=self.cert, verify=self.verify
+        )
         active_client._instance = weakref.ref(self)
 
     def _request(self, method, url, **kwargs):

--- a/ara/clients/utils.py
+++ b/ara/clients/utils.py
@@ -10,6 +10,8 @@ def get_client(
     timeout=30,
     username=None,
     password=None,
+    cert=None,
+    key=None,
     verify=True,
     run_sql_migrations=True,
 ):
@@ -20,6 +22,10 @@ def get_client(
     if username is not None and password is not None:
         auth = HTTPBasicAuth(username, password)
 
+    cert = None
+    if cert is not None and key is not None:
+        cert = (cert, key)
+
     if client == "offline":
         from ara.clients.offline import AraOfflineClient
 
@@ -27,7 +33,7 @@ def get_client(
     elif client == "http":
         from ara.clients.http import AraHttpClient
 
-        return AraHttpClient(endpoint=endpoint, timeout=timeout, auth=auth, verify=verify)
+        return AraHttpClient(endpoint=endpoint, timeout=timeout, auth=auth, cert=cert, verify=verify)
     else:
         raise ValueError("Unsupported API client: %s (use 'http' or 'offline')" % client)
 

--- a/ara/clients/utils.py
+++ b/ara/clients/utils.py
@@ -22,9 +22,11 @@ def get_client(
     if username is not None and password is not None:
         auth = HTTPBasicAuth(username, password)
 
-    cert = None
+    cert_tuple = None
     if cert is not None and key is not None:
-        cert = (cert, key)
+        cert_tuple = (cert, key)
+    elif cert is not None or key is not None:
+        raise ValueError("cert and key must be used together")
 
     if client == "offline":
         from ara.clients.offline import AraOfflineClient
@@ -33,7 +35,7 @@ def get_client(
     elif client == "http":
         from ara.clients.http import AraHttpClient
 
-        return AraHttpClient(endpoint=endpoint, timeout=timeout, auth=auth, cert=cert, verify=verify)
+        return AraHttpClient(endpoint=endpoint, timeout=timeout, auth=auth, cert=cert_tuple, verify=verify)
     else:
         raise ValueError("Unsupported API client: %s (use 'http' or 'offline')" % client)
 

--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -76,6 +76,22 @@ options:
     ini:
       - section: ara
         key: api_password
+  api_cert:
+    description: If a client certificate is required, the path to the certificate to use.
+    default: null
+    env:
+      - name: ARA_API_CERT
+    ini:
+      - section: ara
+        key: api_cert
+  api_key:
+    description: If a client certificate is required, the path to the private key to use.
+    default: null
+    env:
+      - name: ARA_API_KEY
+    ini:
+      - section: ara
+        key: api_key
   api_insecure:
     description: Can be enabled to ignore SSL certification of the API server
     type: bool
@@ -253,6 +269,8 @@ class CallbackModule(CallbackBase):
         timeout = self.get_option("api_timeout")
         username = self.get_option("api_username")
         password = self.get_option("api_password")
+        cert = self.get_option("api_cert")
+        key = self.get_option("api_key")
         insecure = self.get_option("api_insecure")
         self.client = client_utils.get_client(
             client=client,
@@ -260,6 +278,8 @@ class CallbackModule(CallbackBase):
             timeout=timeout,
             username=username,
             password=password,
+            cert=cert,
+            key=key,
             verify=False if insecure else True,
         )
 

--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -92,6 +92,14 @@ options:
     ini:
       - section: ara
         key: api_key
+  api_ca:
+    description: The path to a CA bundle.
+    default: null
+    env:
+      - name: ARA_API_CA
+    ini:
+      - section: ara
+        key: api_ca
   api_insecure:
     description: Can be enabled to ignore SSL certification of the API server
     type: bool
@@ -271,7 +279,13 @@ class CallbackModule(CallbackBase):
         password = self.get_option("api_password")
         cert = self.get_option("api_cert")
         key = self.get_option("api_key")
+        ca = self.get_option("api_ca")
         insecure = self.get_option("api_insecure")
+
+        verify = False if insecure else True
+        if ca:
+            verify = ca
+
         self.client = client_utils.get_client(
             client=client,
             endpoint=endpoint,
@@ -280,7 +294,7 @@ class CallbackModule(CallbackBase):
             password=password,
             cert=cert,
             key=key,
-            verify=False if insecure else True,
+            verify=verify,
         )
 
         # TODO: Consider un-hardcoding this and plumbing pool_maxsize to requests.adapters.HTTPAdapter.


### PR DESCRIPTION
This PR adds support for configuring a TLS client certificate and CA.