### PR TITLE
contrib: bump OS versions for container images

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -46,6 +46,18 @@
     name: ara-container-images
     parent: ara-integration-base
     nodeset: ara-fedora-36
+    files:
+      - ara/*
+      - manage.py
+      - requirements.txt
+      - roles/*
+      - setup.cfg
+      - setup.py
+      - test-requirements.txt
+      - tests/*
+      - tox.ini
+      - .zuul.d/*
+      - contrib/container-images/*
     description: |
       Builds ARA API container images with buildah and briefly tests them with podman.
     run: tests/with_container_images.yaml

--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -199,7 +199,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 USE_TZ = True
-LOCAL_TIME_ZONE = tzlocal.get_localzone().zone
+LOCAL_TIME_ZONE = tzlocal.get_localzone_name()
 TIME_ZONE = settings.get("TIME_ZONE", LOCAL_TIME_ZONE)
 
 # We do not currently support internationalization and localization, turn these

--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -199,7 +199,12 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 USE_TZ = True
+# Under some circumstances tzlocal can't find the local timezone, it will return local or None
+# Default to UTC if this happens.
+# https://github.com/ansible-community/ara/issues/401
 LOCAL_TIME_ZONE = tzlocal.get_localzone_name()
+if LOCAL_TIME_ZONE is None or LOCAL_TIME_ZONE == "local":
+    LOCAL_TIME_ZONE = "UTC"
 TIME_ZONE = settings.get("TIME_ZONE", LOCAL_TIME_ZONE)
 
 # We do not currently support internationalization and localization, turn these

--- a/contrib/container-images/README.rst
+++ b/contrib/container-images/README.rst
@@ -27,15 +27,17 @@ You will need to install `buildah <https://github.com/containers/buildah/blob/ma
 
 The different scripts to build container images are available in the git repository:
 
-- fedora-distribution.sh_: Builds an image from Fedora 35 `distribution packages <https://koji.fedoraproject.org/koji/packageinfo?packageID=24394>`_
-- fedora-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on Fedora 35
-- fedora-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on Fedora 35
+- fedora-distribution.sh_: Builds an image from Fedora 36 `distribution packages <https://koji.fedoraproject.org/koji/packageinfo?packageID=24394>`_
+- fedora-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on Fedora 36
+- fedora-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on Fedora 36
 - centos-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on CentOS 8 Stream
+- centos-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on CentOS 9 Stream
 
 .. _fedora-distribution.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/fedora-distribution.sh
 .. _fedora-pypi.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/fedora-pypi.sh
 .. _fedora-source.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/fedora-source.sh
 .. _centos-pypi.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/centos-pypi.sh
+.. _centos-source.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/centos-source.sh
 
 The scripts have no arguments other than the ability to specify an optional name
 and tag:

--- a/contrib/container-images/centos-pypi.sh
+++ b/contrib/container-images/centos-pypi.sh
@@ -15,6 +15,8 @@ buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y epel-rel
 buildah run "${build}" -- /bin/bash -c "pip3 install ara[server]"
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
+# Temporarily set $TZ env variable pending release of 1.6.0 with timezone fixes
+buildah config --env TZ=UTC
 buildah config --env ARA_BASE_DIR=/opt/ara "${build}"
 buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && /usr/bin/gunicorn-3 --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
 buildah config --port 8000 "${build}"

--- a/contrib/container-images/centos-pypi.sh
+++ b/contrib/container-images/centos-pypi.sh
@@ -2,23 +2,30 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Builds an ARA API server container image using the latest PyPi packages on CentOS Stream 9.
-build=$(buildah from quay.io/centos/centos:stream9)
+# Builds an ARA API server container image using the latest PyPi packages on CentOS Stream 8.
+# TODO: update to stream9 once 1.6.0 is released https://github.com/ansible-community/ara/issues/401
+build=$(buildah from quay.io/centos/centos:stream8)
 
-# Get all updates, install pip, database backends and gunicorn application server
-# This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.
-# Note: We use the packaged versions of psycopg2 and mysql python libraries so
-#       we don't need to install development libraries before installing them from PyPi.
-buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y epel-release && dnf install -y which python3-pip python3-gunicorn python3-psycopg2 python3-mysql && dnf clean all"
+# Ensure everything is up to date and install requirements
+buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-pip-wheel"
 
-# Install ara from source with API server extras for dependencies (django & django-rest-framework)
-buildah run "${build}" -- /bin/bash -c "pip3 install ara[server]"
+# Install development dependencies in a single standalone transaction so we can fully undo it later
+# without leaving dangling uninstalled dependencies
+buildah run "${build}" -- dnf install -y python3-devel gcc postgresql postgresql-devel mariadb-connector-c-devel
+
+# Install ara from PyPI with API server extras for dependencies (django & django-rest-framework)
+# including database backend libraries and gunicorn
+buildah run "${build}" -- python3 -m pip install "ara[server]" "psycopg2-binary<2.9" mysqlclient gunicorn
+
+# Remove development dependencies and clean up
+transaction=$(buildah run "${build}" -- /bin/bash -c "dnf history | grep python3-devel | awk '{print \$1}'")
+buildah run "${build}" -- /bin/bash -c "dnf history undo -y ${transaction} && dnf clean all"
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
 # Temporarily set $TZ env variable pending release of 1.6.0 with timezone fixes
 buildah config --env TZ=UTC
 buildah config --env ARA_BASE_DIR=/opt/ara "${build}"
-buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && /usr/bin/gunicorn-3 --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
+buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && /usr/local/bin/gunicorn --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
 buildah config --port 8000 "${build}"
 
 # Commit this container to an image name

--- a/contrib/container-images/centos-pypi.sh
+++ b/contrib/container-images/centos-pypi.sh
@@ -2,8 +2,8 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Builds an ARA API server container image using the latest PyPi packages on CentOS 8.
-build=$(buildah from quay.io/centos/centos:stream8)
+# Builds an ARA API server container image using the latest PyPi packages on CentOS Stream 9.
+build=$(buildah from quay.io/centos/centos:stream9)
 
 # Get all updates, install pip, database backends and gunicorn application server
 # This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.

--- a/contrib/container-images/centos-source.sh
+++ b/contrib/container-images/centos-source.sh
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Builds an ARA API server container image from checked out source on Fedora 36.
+# Builds an ARA API server container image from checked out source on CentOS Stream 9.
 # Figure out source directory relative to the contrib/container-images directory
 SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 SOURCE_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd -P)
@@ -13,14 +13,14 @@ python3 setup.py sdist
 sdist=$(ls dist/ara-*.tar.gz)
 popd
 
-build=$(buildah from quay.io/fedora/fedora:36)
+build=$(buildah from quay.io/centos/centos:stream9)
 
 # Ensure everything is up to date and install requirements
-buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-wheel"
+buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-pip-wheel"
 
 # Install development dependencies in a single standalone transaction so we can fully undo it later
 # without leaving dangling uninstalled dependencies
-buildah run "${build}" -- dnf install -y python3-devel gcc postgresql postgresql-devel mysql-devel
+buildah run "${build}" -- dnf install -y python3-devel gcc postgresql postgresql-devel mariadb-connector-c-devel
 
 # Install ara from source with API server extras for dependencies (django & django-rest-framework)
 # including database backend libraries and gunicorn

--- a/contrib/container-images/fedora-distribution.sh
+++ b/contrib/container-images/fedora-distribution.sh
@@ -2,8 +2,8 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Builds an ARA API server container image from Fedora 35 distribution packages.
-build=$(buildah from quay.io/fedora/fedora:35)
+# Builds an ARA API server container image from Fedora 36 distribution packages.
+build=$(buildah from quay.io/fedora/fedora:36)
 
 # Get all updates, install the ARA API server, database backends and gunicorn application server
 # This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.

--- a/contrib/container-images/fedora-pypi.sh
+++ b/contrib/container-images/fedora-pypi.sh
@@ -5,18 +5,24 @@
 # Builds an ARA API server container image using the latest PyPi packages on Fedora 36.
 build=$(buildah from quay.io/fedora/fedora:36)
 
-# Get all updates, install pip, database backends and gunicorn application server
-# This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.
-# Note: We use the packaged versions of psycopg2 and mysql python libraries so
-#       we don't need to install development libraries before installing them from PyPi.
-buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-psycopg2 python3-mysql python3-gunicorn && dnf clean all"
+# Ensure everything is up to date and install requirements
+buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-wheel"
 
-# Install ara from source with API server extras for dependencies (django & django-rest-framework)
-buildah run "${build}" -- /bin/bash -c "pip3 install ara[server]"
+# Install development dependencies in a single standalone transaction so we can fully undo it later
+# without leaving dangling uninstalled dependencies
+buildah run "${build}" -- dnf install -y python3-devel gcc postgresql postgresql-devel mysql-devel
+
+# Install ara from PyPI with API server extras for dependencies (django & django-rest-framework)
+# including database backend libraries and gunicorn
+buildah run "${build}" -- python3 -m pip install "ara[server]" "psycopg2-binary<2.9" mysqlclient gunicorn
+
+# Remove development dependencies and clean up
+transaction=$(buildah run "${build}" -- /bin/bash -c "dnf history | grep python3-devel | awk '{print \$1}'")
+buildah run "${build}" -- /bin/bash -c "dnf history undo -y ${transaction} && dnf clean all"
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
 buildah config --env ARA_BASE_DIR=/opt/ara "${build}"
-buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && /usr/bin/gunicorn-3 --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
+buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && /usr/local/bin/gunicorn --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
 buildah config --port 8000 "${build}"
 
 # Commit this container to an image name

--- a/contrib/container-images/fedora-pypi.sh
+++ b/contrib/container-images/fedora-pypi.sh
@@ -2,8 +2,8 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Builds an ARA API server container image using the latest PyPi packages on Fedora 35.
-build=$(buildah from quay.io/fedora/fedora:35)
+# Builds an ARA API server container image using the latest PyPi packages on Fedora 36.
+build=$(buildah from quay.io/fedora/fedora:36)
 
 # Get all updates, install pip, database backends and gunicorn application server
 # This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.

--- a/contrib/container-images/fedora-source.sh
+++ b/contrib/container-images/fedora-source.sh
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Builds an ARA API server container image from checked out source on Fedora 35.
+# Builds an ARA API server container image from checked out source on Fedora 36.
 # Figure out source directory relative to the contrib/container-images directory
 SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 SOURCE_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd -P)
@@ -13,7 +13,7 @@ python3 setup.py sdist
 sdist=$(ls dist/ara-*.tar.gz)
 popd
 
-build=$(buildah from quay.io/fedora/fedora:35)
+build=$(buildah from quay.io/fedora/fedora:36)
 
 # Get all updates, install pip, database backends and gunicorn application server
 # This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ server=
     # dynaconf dropped support for py35 at version 3.0.0: https://github.com/ansible-community/ara/issues/370
     dynaconf[yaml]>=3.0.0,!=3.1.3,<4.0.0;python_version>='3.6'
     dynaconf[yaml]<3.0.0;python_version<'3.6'
-    tzlocal<3.0
+    tzlocal>=4.0
     whitenoise
     pygments
 postgresql=

--- a/tests/with_container_images.yaml
+++ b/tests/with_container_images.yaml
@@ -11,18 +11,21 @@
     images:
       # These are in chronological order of release so that we don't end up
       # running SQL migrations backwards during the tests.
-      - name: localhost/ara-api
-        tag: fedora35-source-latest
+      - tag: fedora36-source-latest
         script: fedora-source.sh
-      - name: localhost/ara-api
-        tag: fedora35-pypi-latest
+        name: localhost/ara-api
+      - tag: centos9-source-latest
+        script: centos-source.sh
+        name: localhost/ara-api
+      - tag: fedora36-pypi-latest
         script: fedora-pypi.sh
-      - name: localhost/ara-api
-        tag: centos8-stream-pypi-latest
+        name: localhost/ara-api
+      - tag: centos8-pypi-latest
         script: centos-pypi.sh
-      - name: localhost/ara-api
-        tag: fedora35-distribution-latest
+        name: localhost/ara-api
+      - tag: fedora36-distribution-latest
         script: fedora-distribution.sh
+        name: localhost/ara-api
   tasks:
     - name: Install git, buildah and podman
       become: true

--- a/tests/zuul_publish_container_images.yaml
+++ b/tests/zuul_publish_container_images.yaml
@@ -9,23 +9,30 @@
     destination: "{{ destination_repository | default('docker.io/recordsansible/ara-api') }}"
     images:
       # These images are meant to be provided by the "with_container_images.yaml" playbook
-      - name: localhost/ara-api
-        tag: fedora35-source-latest
-      - name: localhost/ara-api
-        tag: fedora35-pypi-latest
-      - name: localhost/ara-api
-        tag: centos8-stream-pypi-latest
-      - name: localhost/ara-api
-        tag: fedora35-distribution-latest
+      - tag: fedora36-source-latest
+        script: fedora-source.sh
+        name: localhost/ara-api
+      - tag: centos9-source-latest
+        script: centos-source.sh
+        name: localhost/ara-api
+      - tag: fedora36-pypi-latest
+        script: fedora-pypi.sh
+        name: localhost/ara-api
+      - tag: centos8-pypi-latest
+        script: centos-pypi.sh
+        name: localhost/ara-api
+      - tag: fedora36-distribution-latest
+        script: fedora-distribution.sh
+        name: localhost/ara-api
   tasks:
     - name: Tag images with buildah
       command: |
         buildah tag {{ item.name }}:{{ item.tag }} {{ destination }}:{{ item.tag }}
       loop: "{{ images }}"
 
-    - name: Tag latest from fedora35-pypi-latest
+    - name: Tag latest from fedora36-pypi-latest
       command: |
-        buildah tag {{ destination }}:fedora35-pypi-latest {{ destination }}:latest
+        buildah tag {{ destination }}:fedora36-pypi-latest {{ destination }}:latest
 
     - name: Push latest
       command: |


### PR DESCRIPTION
- Update from CentOS Stream 8 to Stream 9
- Update from Fedora 35 to Fedora 36