### PR TITLE
ui: ability to search by host or task name

### DIFF
--- a/ara/api/filters.py
+++ b/ara/api/filters.py
@@ -184,8 +184,10 @@ class LatestHostFilter(BaseFilter):
 class ResultFilter(DateFilter):
     playbook = django_filters.NumberFilter(field_name="playbook__id", lookup_expr="exact")
     task = django_filters.NumberFilter(field_name="task__id", lookup_expr="exact")
+    task_name = django_filters.CharFilter(field_name="task__name", lookup_expr="icontains")
     play = django_filters.NumberFilter(field_name="play__id", lookup_expr="exact")
     host = django_filters.NumberFilter(field_name="host__id", lookup_expr="exact")
+    host_name = django_filters.CharFilter(field_name="host__name", lookup_expr="iexact")
     delegated_to = django_filters.NumberFilter(field_name="delegated_to__id", lookup_expr="exact")
     changed = django_filters.BooleanFilter(field_name="changed", lookup_expr="exact")
     status = django_filters.MultipleChoiceFilter(

--- a/ara/ui/forms.py
+++ b/ara/ui/forms.py
@@ -20,8 +20,8 @@ class PlaybookSearchForm(forms.Form):
 
 
 class ResultSearchForm(forms.Form):
-    host = forms.CharField(label="Host id", max_length=10, required=False)
-    task = forms.CharField(label="Task id", max_length=10, required=False)
+    host_name = forms.CharField(label="Host name", max_length=255, required=False)
+    task_name = forms.CharField(label="Task name", required=False)
     changed = forms.BooleanField(label="Changed", required=False)
 
     status = forms.MultipleChoiceField(

--- a/ara/ui/templates/partials/host_results.html
+++ b/ara/ui/templates/partials/host_results.html
@@ -56,8 +56,8 @@
                   <div class="card-body">
                     <div class="form-row">
                       <div class="form-group col-xl-4">
-                        <label for="task" {% if request.GET.task %}style="font-weight:bold;"{% endif %}>Task ID</label>
-                        <input type="text" class="form-control" id="task" name="task" placeholder="ex: 1234" value="{{ search_form.task.value | default_if_none:'' }}">
+                        <label for="task_name" {% if request.GET.task_name %}style="font-weight:bold;"{% endif %}>Task name</label>
+                        <input type="text" class="form-control" id="task_name" name="task_name" placeholder="ex: Install httpd" value="{{ search_form.task_name.value | default_if_none:'' }}">
                       </div>
                     </div>
                     <div class="form-row">
@@ -173,7 +173,7 @@
                   </td>
                   <td>
                     {% if not static_generation %}
-                      <a href="{% static_url playbook_url %}?task={{ result.task.id }}#results">{{ result.task.name }}</a>
+                      <a href="{% static_url playbook_url %}?task_name={{ result.task.name }}#results">{{ result.task.name }}</a>
                     {% else %}
                       {{ result.task.name }}
                     {% endif %}

--- a/ara/ui/templates/partials/playbook_results.html
+++ b/ara/ui/templates/partials/playbook_results.html
@@ -33,12 +33,12 @@
                   <div class="card-body">
                     <div class="form-row">
                       <div class="form-group col-xl-4">
-                        <label for="host" {% if request.GET.host %}style="font-weight:bold;"{% endif %}>Host ID</label>
-                        <input type="text" class="form-control" id="host" name="host" placeholder="ex: 1234" value="{{ search_form.host.value | default_if_none:'' }}">
+                        <label for="host_name" {% if request.GET.host_name %}style="font-weight:bold;"{% endif %}>Host name</label>
+                        <input type="text" class="form-control" id="host_name" name="host_name" placeholder="ex: host1234" value="{{ search_form.host_name.value | default_if_none:'' }}">
                       </div>
                       <div class="form-group col-xl-4">
-                        <label for="task" {% if request.GET.task %}style="font-weight:bold;"{% endif %}>Task ID</label>
-                        <input type="text" class="form-control" id="task" name="task" placeholder="ex: 1234" value="{{ search_form.task.value | default_if_none:'' }}">
+                        <label for="task_name" {% if request.GET.task_name %}style="font-weight:bold;"{% endif %}>Task name</label>
+                        <input type="text" class="form-control" id="task_name" name="task_name" placeholder="ex: Install httpd" value="{{ search_form.task_name.value | default_if_none:'' }}">
                       </div>
                     </div>
                     <div class="form-row">
@@ -136,7 +136,7 @@
                   </td>
                   <td>
                     {% if not static_generation %}
-                      <a href="{% url 'ui:playbook' playbook.id %}?host={{ result.host.id }}#results">{{ result.host.name }}</a>
+                      <a href="{% url 'ui:playbook' playbook.id %}?host_name={{ result.host.name }}#results">{{ result.host.name }}</a>
                     {% else %}
                       {{ result.host.name }}
                     {% endif %}
@@ -159,7 +159,7 @@
                   </td>
                   <td>
                     {% if not static_generation %}
-                      <a href="{% url 'ui:playbook' playbook.id %}?task={{ result.task.id }}#results">{{ result.task.name }}</a>
+                      <a href="{% url 'ui:playbook' playbook.id %}?task_name={{ result.task.name }}#results">{{ result.task.name }}</a>
                     {% else %}
                       {{ result.task.name }}
                     {% endif %}


### PR DESCRIPTION
Ability to search for host or task name instead of id (fixes #243)
![image](https://user-images.githubusercontent.com/38468371/183352570-8f66cf69-90d0-492c-8fab-186a0dc99af7.png)

Furthermore this PR introduces host and task name filters on the playbook index as well
![image](https://user-images.githubusercontent.com/38468371/183352715-e58ad641-a6bf-4243-8d13-9368b87df8c1.png)

While the taskfilter supports pattern search (`icontains`), the host filter expects case insensitve exact expression (`iexact`). Because imo that's how most will use it.

