### PR TITLE
contrib/zuul: List the container images that were built

### DIFF
--- a/tests/with_container_images.yaml
+++ b/tests/with_container_images.yaml
@@ -51,6 +51,12 @@
             policy: targeted
             state: permissive
 
-    - name: Test each container image
-      include_tasks: container_test_tasks.yaml
-      loop: "{{ images }}"
+    - block:
+        - name: Test each container image
+          include_tasks: container_test_tasks.yaml
+          loop: "{{ images }}"
+
+      always:
+        - name: List built container images
+          command: buildah images
+          changed_when: false

--- a/tests/zuul_publish_container_images.yaml
+++ b/tests/zuul_publish_container_images.yaml
@@ -25,6 +25,10 @@
         script: fedora-distribution.sh
         name: localhost/ara-api
   tasks:
+    - name: List built container images
+      command: buildah images
+      changed_when: false
+
     - name: Tag images with buildah
       command: |
         buildah tag {{ item.name }}:{{ item.tag }} {{ destination }}:{{ item.tag }}

--- a/tests/zuul_publish_container_images.yaml
+++ b/tests/zuul_publish_container_images.yaml
@@ -4,25 +4,19 @@
 - name: Publish container images
   hosts: all
   gather_facts: yes
-  become: yes
   vars:
     destination: "{{ destination_repository | default('docker.io/recordsansible/ara-api') }}"
     images:
       # These images are meant to be provided by the "with_container_images.yaml" playbook
       - tag: fedora36-source-latest
-        script: fedora-source.sh
         name: localhost/ara-api
       - tag: centos9-source-latest
-        script: centos-source.sh
         name: localhost/ara-api
       - tag: fedora36-pypi-latest
-        script: fedora-pypi.sh
         name: localhost/ara-api
       - tag: centos8-pypi-latest
-        script: centos-pypi.sh
         name: localhost/ara-api
       - tag: fedora36-distribution-latest
-        script: fedora-distribution.sh
         name: localhost/ara-api
   tasks:
     - name: List built container images


### PR DESCRIPTION
To help troubleshooting when there are issues, run a 'buildah images' to
list the images that were built as part of the job.