### PR TITLE
contrib: Various container image fixes

### DIFF
--- a/contrib/container-images/centos-pypi.sh
+++ b/contrib/container-images/centos-pypi.sh
@@ -1,29 +1,28 @@
 #!/bin/bash -x
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+DEV_DEPENDENCIES="gcc python3-devel postgresql-devel mariadb-connector-c-devel"
 
 # Builds an ARA API server container image using the latest PyPi packages on CentOS Stream 8.
 # TODO: update to stream9 once 1.6.0 is released https://github.com/ansible-community/ara/issues/401
 build=$(buildah from quay.io/centos/centos:stream8)
 
 # Ensure everything is up to date and install requirements
-buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-pip-wheel"
+buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-pip-wheel postgresql libpq mariadb-connector-c"
 
-# Install development dependencies in a single standalone transaction so we can fully undo it later
-# without leaving dangling uninstalled dependencies
-buildah run "${build}" -- dnf install -y python3-devel gcc postgresql postgresql-devel mariadb-connector-c-devel
+# Install development dependencies required for installing packages from PyPI
+buildah run "${build}" -- dnf install -y ${DEV_DEPENDENCIES}
 
 # Install ara from PyPI with API server extras for dependencies (django & django-rest-framework)
 # including database backend libraries and gunicorn
-buildah run "${build}" -- python3 -m pip install "ara[server]" "psycopg2-binary<2.9" mysqlclient gunicorn
+buildah run "${build}" -- python3 -m pip install "ara[server]" "psycopg2<2.9" mysqlclient gunicorn
 
 # Remove development dependencies and clean up
-transaction=$(buildah run "${build}" -- /bin/bash -c "dnf history | grep python3-devel | awk '{print \$1}'")
-buildah run "${build}" -- /bin/bash -c "dnf history undo -y ${transaction} && dnf clean all"
+buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all"
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
 # Temporarily set $TZ env variable pending release of 1.6.0 with timezone fixes
-buildah config --env TZ=UTC
+buildah config --env TZ=UTC "${build}"
 buildah config --env ARA_BASE_DIR=/opt/ara "${build}"
 buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && /usr/local/bin/gunicorn --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
 buildah config --port 8000 "${build}"

--- a/contrib/container-images/centos-pypi.sh
+++ b/contrib/container-images/centos-pypi.sh
@@ -18,7 +18,7 @@ buildah run "${build}" -- dnf install -y ${DEV_DEPENDENCIES}
 buildah run "${build}" -- python3 -m pip install "ara[server]" "psycopg2<2.9" mysqlclient gunicorn
 
 # Remove development dependencies and clean up
-buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all"
+buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all && python3 -m pip cache purge"
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
 # Temporarily set $TZ env variable pending release of 1.6.0 with timezone fixes

--- a/contrib/container-images/centos-source.sh
+++ b/contrib/container-images/centos-source.sh
@@ -27,7 +27,7 @@ buildah run "${build}" -- dnf install -y ${DEV_DEPENDENCIES}
 buildah run --volume ${SOURCE_DIR}:/usr/local/src/ara:z "${build}" -- python3 -m pip install "/usr/local/src/ara/${sdist}[server]" psycopg2 mysqlclient gunicorn
 
 # Remove development dependencies and clean up
-buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all"
+buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all && python3 -m pip cache purge"
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
 buildah config --env ARA_BASE_DIR=/opt/ara "${build}"

--- a/contrib/container-images/fedora-pypi.sh
+++ b/contrib/container-images/fedora-pypi.sh
@@ -17,7 +17,7 @@ buildah run "${build}" -- dnf install -y ${DEV_DEPENDENCIES}
 buildah run "${build}" -- python3 -m pip install "ara[server]" "psycopg2<2.9" mysqlclient gunicorn
 
 # Remove development dependencies and clean up
-buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all"
+buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all && python3 -m pip cache purge"
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
 buildah config --env ARA_BASE_DIR=/opt/ara "${build}"

--- a/contrib/container-images/fedora-source.sh
+++ b/contrib/container-images/fedora-source.sh
@@ -27,7 +27,7 @@ buildah run "${build}" -- dnf install -y ${DEV_DEPENDENCIES}
 buildah run --volume ${SOURCE_DIR}:/usr/local/src/ara:z "${build}" -- python3 -m pip install "/usr/local/src/ara/${sdist}[server]" psycopg2 mysqlclient gunicorn
 
 # Remove development dependencies and clean up
-buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all"
+buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all && python3 -m pip cache purge"
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
 buildah config --env ARA_BASE_DIR=/opt/ara "${build}"

--- a/contrib/container-images/fedora-source.sh
+++ b/contrib/container-images/fedora-source.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -x
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+DEV_DEPENDENCIES="gcc python3-devel postgresql-devel mariadb-devel"
 
 # Builds an ARA API server container image from checked out source on Fedora 36.
 # Figure out source directory relative to the contrib/container-images directory
@@ -16,19 +17,17 @@ popd
 build=$(buildah from quay.io/fedora/fedora:36)
 
 # Ensure everything is up to date and install requirements
-buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-wheel"
+buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-wheel postgresql libpq mariadb-connector-c"
 
-# Install development dependencies in a single standalone transaction so we can fully undo it later
-# without leaving dangling uninstalled dependencies
-buildah run "${build}" -- dnf install -y python3-devel gcc postgresql postgresql-devel mysql-devel
+# Install development dependencies required for installing packages from PyPI
+buildah run "${build}" -- dnf install -y ${DEV_DEPENDENCIES}
 
 # Install ara from source with API server extras for dependencies (django & django-rest-framework)
 # including database backend libraries and gunicorn
-buildah run --volume ${SOURCE_DIR}:/usr/local/src/ara:z "${build}" -- python3 -m pip install "/usr/local/src/ara/${sdist}[server]" "psycopg2-binary<2.9" mysqlclient gunicorn
+buildah run --volume ${SOURCE_DIR}:/usr/local/src/ara:z "${build}" -- python3 -m pip install "/usr/local/src/ara/${sdist}[server]" psycopg2 mysqlclient gunicorn
 
 # Remove development dependencies and clean up
-transaction=$(buildah run "${build}" -- /bin/bash -c "dnf history | grep python3-devel | awk '{print \$1}'")
-buildah run "${build}" -- /bin/bash -c "dnf history undo -y ${transaction} && dnf clean all"
+buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all"
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
 buildah config --env ARA_BASE_DIR=/opt/ara "${build}"


### PR DESCRIPTION
- Fix mysql/postgresql support that was broken in recent overhaul
- Drop psycopg2-binary and go back to psycopg2, at first glance it
  doesn't work in-place with django
- Keep psycopg2<2.9 requirement for pypi images but remove it from the
  source images since django 3.2 fixes support for psycopg2>2.9. We
  can lift the requirement for the pypi images once ara 1.6.0 is out.
- Fix 'dnf history undo' implementation to uninstall development
  dependencies
- Fix missing container ID when setting the timezone for centos-pypi