### PR TITLE
CLI: prefix ssl arguments with "ssl-"

### DIFF
--- a/ara/cli/base.py
+++ b/ara/cli/base.py
@@ -46,19 +46,19 @@ def global_arguments(parser):
         help=("API server password for authentication, defaults to ARA_API_PASSWORD or None"),
     )
     parser.add_argument(
-        "--cert",
+        "--ssl-cert",
         metavar="<path/to/certificate>",
         default=os.environ.get("ARA_API_CERT", None),
         help=("If a client certificate is required, the path to the certificate to use"),
     )
     parser.add_argument(
-        "--key",
+        "--ssl-key",
         metavar="<path/to/key>",
         default=os.environ.get("ARA_API_KEY", None),
         help=("If a client certificate is required, the path to the private key to use"),
     )
     parser.add_argument(
-        "--ca",
+        "--ssl-ca",
         metavar="<path/to/cacert>",
         default=os.environ.get("ARA_API_CA", None),
         help=("Path to a certificate authority for trusting the API server certificate"),

--- a/ara/cli/expire.py
+++ b/ara/cli/expire.py
@@ -55,16 +55,16 @@ class ExpireObjects(Command):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )

--- a/ara/cli/host.py
+++ b/ara/cli/host.py
@@ -118,16 +118,16 @@ class HostList(Lister):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -215,16 +215,16 @@ class HostShow(ShowOne):
             self.log.warn("Rendering using default table formatter, use '-f yaml' or '-f json' for improved display.")
 
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -287,16 +287,16 @@ class HostDelete(Command):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -392,16 +392,16 @@ class HostMetrics(Lister):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )

--- a/ara/cli/play.py
+++ b/ara/cli/play.py
@@ -81,16 +81,16 @@ class PlayList(Lister):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -155,16 +155,16 @@ class PlayShow(ShowOne):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -214,16 +214,16 @@ class PlayDelete(Command):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )

--- a/ara/cli/playbook.py
+++ b/ara/cli/playbook.py
@@ -88,16 +88,16 @@ class PlaybookList(Lister):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -199,16 +199,16 @@ class PlaybookShow(ShowOne):
             self.log.warn("Rendering using default table formatter, use '-f yaml' or '-f json' for improved display.")
 
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -256,16 +256,16 @@ class PlaybookDelete(Command):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -350,16 +350,16 @@ class PlaybookPrune(Command):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -494,16 +494,16 @@ class PlaybookMetrics(Lister):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )

--- a/ara/cli/record.py
+++ b/ara/cli/record.py
@@ -69,16 +69,16 @@ class RecordList(Lister):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -137,16 +137,16 @@ class RecordShow(ShowOne):
             self.log.warn("Rendering using default table formatter, use '-f yaml' or '-f json' for improved display.")
 
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -194,16 +194,16 @@ class RecordDelete(Command):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )

--- a/ara/cli/result.py
+++ b/ara/cli/result.py
@@ -103,16 +103,16 @@ class ResultList(Lister):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -220,16 +220,16 @@ class ResultShow(ShowOne):
             self.log.warn("Rendering using default table formatter, use '-f yaml' or '-f json' for improved display.")
 
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -307,16 +307,16 @@ class ResultDelete(Command):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )

--- a/ara/cli/task.py
+++ b/ara/cli/task.py
@@ -88,16 +88,16 @@ class TaskList(Lister):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -194,16 +194,16 @@ class TaskShow(ShowOne):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -251,16 +251,16 @@ class TaskDelete(Command):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )
@@ -343,16 +343,16 @@ class TaskMetrics(Lister):
 
     def take_action(self, args):
         verify = False if args.insecure else True
-        if args.ca:
-            verify = args.ca
+        if args.ssl_ca:
+            verify = args.ssl_ca
         client = get_client(
             client=args.client,
             endpoint=args.server,
             timeout=args.timeout,
             username=args.username,
             password=args.password,
-            cert=args.cert,
-            key=args.key,
+            cert=args.ssl_cert,
+            key=args.ssl_key,
             verify=verify,
             run_sql_migrations=False,
         )


### PR DESCRIPTION
When first implementing support for ssl key/cert/ca validation in the CLI, we missed that there was already a --key argument, used for ara_record keys.

Add a prefix to the ssl arguments such that --key becomes --ssl-key in order to resolve the conflict.