### PR TITLE
Auto format codebase to py36+

### DIFF
--- a/ara/api/models.py
+++ b/ara/api/models.py
@@ -34,7 +34,7 @@ class Duration(Base):
         # Compute duration based on available timestamps
         if self.ended is not None:
             self.duration = self.ended - self.started
-        return super(Duration, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
 
 class Label(Base):

--- a/ara/api/tests/tests_playbook.py
+++ b/ara/api/tests/tests_playbook.py
@@ -85,7 +85,7 @@ class PlaybookTestCase(APITestCase):
         self.assertEqual(201, request.status_code)
         self.assertEqual(1, models.Playbook.objects.count())
         self.assertEqual(request.data["status"], "running")
-        self.assertEqual(sorted([label["name"] for label in request.data["labels"]]), sorted(labels))
+        self.assertEqual(sorted(label["name"] for label in request.data["labels"]), sorted(labels))
 
     def test_partial_update_playbook(self):
         playbook = factories.PlaybookFactory()

--- a/ara/api/tests/tests_prune.py
+++ b/ara/api/tests/tests_prune.py
@@ -12,7 +12,7 @@ from ara.api import models
 from ara.api.tests import factories
 
 
-class LogCheckerMixin(object):
+class LogCheckerMixin:
     def run_prune_command(self, *args, **opts):
         # the command uses logging instead of prints so we need to use assertLogs
         # to retrieve and test the output

--- a/ara/api/tests/tests_utils.py
+++ b/ara/api/tests/tests_utils.py
@@ -8,7 +8,7 @@ from rest_framework.test import APITestCase
 class RootTestCase(APITestCase):
     def test_root_endpoint(self):
         result = self.client.get("/api/")
-        self.assertEqual(set(result.data.keys()), set(["kind", "version", "api"]))
+        self.assertEqual(set(result.data.keys()), {"kind", "version", "api"})
         self.assertEqual(result.data["kind"], "ara")
         self.assertEqual(result.data["version"], pkg_resources.get_distribution("ara").version)
         self.assertEqual(len(result.data["api"]), 1)

--- a/ara/cli/base.py
+++ b/ara/cli/base.py
@@ -75,7 +75,7 @@ def global_arguments(parser):
 
 class AraCli(App):
     def __init__(self):
-        super(AraCli, self).__init__(
+        super().__init__(
             description="A CLI client to query ARA API servers",
             version=CLIENT_VERSION,
             command_manager=CommandManager("ara.cli"),
@@ -83,7 +83,7 @@ class AraCli(App):
         )
 
     def build_option_parser(self, description, version):
-        parser = super(AraCli, self).build_option_parser(description, version)
+        parser = super().build_option_parser(description, version)
         return parser
 
     def initialize_app(self, argv):

--- a/ara/cli/expire.py
+++ b/ara/cli/expire.py
@@ -20,7 +20,7 @@ class ExpireObjects(Command):
     expired = 0
 
     def get_parser(self, prog_name):
-        parser = super(ExpireObjects, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(

--- a/ara/cli/host.py
+++ b/ara/cli/host.py
@@ -20,7 +20,7 @@ class HostList(Lister):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(HostList, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         # Host search arguments and ordering as per ara.api.filters.HostFilter
@@ -193,7 +193,7 @@ class HostShow(ShowOne):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(HostShow, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(
@@ -274,7 +274,7 @@ class HostDelete(Command):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(HostDelete, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(
@@ -311,7 +311,7 @@ class HostMetrics(Lister):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(HostMetrics, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         # Host search arguments and ordering as per ara.api.filters.HostFilter

--- a/ara/cli/play.py
+++ b/ara/cli/play.py
@@ -20,7 +20,7 @@ class PlayList(Lister):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(PlayList, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         # Play search arguments and ordering as per ara.api.filters.PlayFilter
@@ -142,7 +142,7 @@ class PlayShow(ShowOne):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(PlayShow, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(
@@ -201,7 +201,7 @@ class PlayDelete(Command):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(PlayDelete, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(

--- a/ara/cli/playbook.py
+++ b/ara/cli/playbook.py
@@ -21,7 +21,7 @@ class PlaybookList(Lister):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(PlaybookList, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         # Playbook search arguments and ordering as per ara.api.filters.PlaybookFilter
@@ -182,7 +182,7 @@ class PlaybookShow(ShowOne):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(PlaybookShow, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(
@@ -243,7 +243,7 @@ class PlaybookDelete(Command):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(PlaybookDelete, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(
@@ -281,7 +281,7 @@ class PlaybookPrune(Command):
     deleted = 0
 
     def get_parser(self, prog_name):
-        parser = super(PlaybookPrune, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(
@@ -421,7 +421,7 @@ class PlaybookMetrics(Lister):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(PlaybookMetrics, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(

--- a/ara/cli/record.py
+++ b/ara/cli/record.py
@@ -20,7 +20,7 @@ class RecordList(Lister):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(RecordList, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         # Record search arguments and ordering as per ara.api.filters.RecordFilter
@@ -120,7 +120,7 @@ class RecordShow(ShowOne):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(RecordShow, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(
@@ -181,7 +181,7 @@ class RecordDelete(Command):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(RecordDelete, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(

--- a/ara/cli/result.py
+++ b/ara/cli/result.py
@@ -20,7 +20,7 @@ class ResultList(Lister):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(ResultList, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         # Result search arguments and ordering as per ara.api.filters.ResultFilter
@@ -198,7 +198,7 @@ class ResultShow(ShowOne):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(ResultShow, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(
@@ -294,7 +294,7 @@ class ResultDelete(Command):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(ResultDelete, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(

--- a/ara/cli/task.py
+++ b/ara/cli/task.py
@@ -21,7 +21,7 @@ class TaskList(Lister):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(TaskList, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         # Task search arguments and ordering as per ara.api.filters.TaskFilter
@@ -181,7 +181,7 @@ class TaskShow(ShowOne):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(TaskShow, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(
@@ -238,7 +238,7 @@ class TaskDelete(Command):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(TaskDelete, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(
@@ -275,7 +275,7 @@ class TaskMetrics(Lister):
     log = logging.getLogger(__name__)
 
     def get_parser(self, prog_name):
-        parser = super(TaskMetrics, self).get_parser(prog_name)
+        parser = super().get_parser(prog_name)
         parser = global_arguments(parser)
         # fmt: off
         parser.add_argument(

--- a/ara/clients/http.py
+++ b/ara/clients/http.py
@@ -14,7 +14,7 @@ from ara.clients.utils import active_client
 CLIENT_VERSION = pbr.version.VersionInfo("ara").release_string()
 
 
-class HttpClient(object):
+class HttpClient:
     def __init__(self, endpoint="http://127.0.0.1:8000", auth=None, cert=None, timeout=30, verify=True):
         self.log = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ class HttpClient(object):
         return self._request("delete", url)
 
 
-class AraHttpClient(object):
+class AraHttpClient:
     def __init__(self, endpoint="http://127.0.0.1:8000", auth=None, cert=None, timeout=30, verify=True):
         self.log = logging.getLogger(__name__)
         self.endpoint = endpoint
@@ -85,12 +85,12 @@ class AraHttpClient(object):
             response = func(url, **kwargs)
 
         if response.status_code >= 500:
-            self.log.error("Failed to {method} on {url}: {content}".format(method=method, url=url, content=kwargs))
+            self.log.error(f"Failed to {method} on {url}: {kwargs}")
 
-        self.log.debug("HTTP {status}: {method} on {url}".format(status=response.status_code, method=method, url=url))
+        self.log.debug(f"HTTP {response.status_code}: {method} on {url}")
 
         if response.status_code not in [200, 201, 204]:
-            self.log.error("Failed to {method} on {url}: {content}".format(method=method, url=url, content=kwargs))
+            self.log.error(f"Failed to {method} on {url}: {kwargs}")
 
         if response.status_code == 204:
             return response

--- a/ara/plugins/action/ara_playbook.py
+++ b/ara/plugins/action/ara_playbook.py
@@ -53,10 +53,10 @@ class ActionModule(ActionBase):
     """Retrieves either a specific playbook from ARA or the one currently running"""
 
     TRANSFERS_FILES = False
-    VALID_ARGS = frozenset(("playbook_id"))
+    VALID_ARGS = frozenset("playbook_id")
 
     def __init__(self, *args, **kwargs):
-        super(ActionModule, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.client = client_utils.active_client()
 
     def run(self, tmp=None, task_vars=None):
@@ -65,10 +65,10 @@ class ActionModule(ActionBase):
 
         for arg in self._task.args:
             if arg not in self.VALID_ARGS:
-                result = {"failed": True, "msg": "{0} is not a valid option.".format(arg)}
+                result = {"failed": True, "msg": f"{arg} is not a valid option."}
                 return result
 
-        result = super(ActionModule, self).run(tmp, task_vars)
+        result = super().run(tmp, task_vars)
 
         playbook_id = self._task.args.get("playbook_id", None)
         if playbook_id is None:

--- a/ara/plugins/action/ara_record.py
+++ b/ara/plugins/action/ara_record.py
@@ -125,7 +125,7 @@ class ActionModule(ActionBase):
     VALID_TYPES = ["text", "url", "json", "list", "dict"]
 
     def __init__(self, *args, **kwargs):
-        super(ActionModule, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.client = client_utils.active_client()
 
     def create_or_update_key(self, playbook, key, value, type):
@@ -151,10 +151,10 @@ class ActionModule(ActionBase):
 
         for arg in self._task.args:
             if arg not in self.VALID_ARGS:
-                result = {"failed": True, "msg": "{0} is not a valid option.".format(arg)}
+                result = {"failed": True, "msg": f"{arg} is not a valid option."}
                 return result
 
-        result = super(ActionModule, self).run(tmp, task_vars)
+        result = super().run(tmp, task_vars)
 
         playbook_id = self._task.args.get("playbook_id", None)
         key = self._task.args.get("key", None)
@@ -165,12 +165,12 @@ class ActionModule(ActionBase):
         for parameter in required:
             if not self._task.args.get(parameter):
                 result["failed"] = True
-                result["msg"] = "Parameter '{0}' is required".format(parameter)
+                result["msg"] = f"Parameter '{parameter}' is required"
                 return result
 
         if type not in self.VALID_TYPES:
             result["failed"] = True
-            msg = "Type '{0}' is not supported, choose one of: {1}".format(type, ", ".join(self.VALID_TYPES))
+            msg = "Type '{}' is not supported, choose one of: {}".format(type, ", ".join(self.VALID_TYPES))
             result["msg"] = msg
             return result
 
@@ -200,5 +200,5 @@ class ActionModule(ActionBase):
         except Exception as e:
             result["changed"] = False
             result["failed"] = True
-            result["msg"] = "Record failed to be created or updated in ARA: {0}".format(str(e))
+            result["msg"] = f"Record failed to be created or updated in ARA: {str(e)}"
         return result

--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
 
 import datetime
 import json
@@ -238,7 +237,7 @@ class CallbackModule(CallbackBase):
     CALLBACK_NAME = "ara_default"
 
     def __init__(self):
-        super(CallbackModule, self).__init__()
+        super().__init__()
         self.log = logging.getLogger("ara.plugins.callback.default")
         self.localhost_hostname = None
         # These are configured in self.set_options
@@ -264,7 +263,7 @@ class CallbackModule(CallbackBase):
         self.delegation_cache = {}
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
-        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+        super().set_options(task_keys=task_keys, var_options=var_options, direct=direct)
 
         self.argument_labels = self.get_option("argument_labels")
         self.default_labels = self.get_option("default_labels")
@@ -340,8 +339,8 @@ class CallbackModule(CallbackBase):
         if playbook._file_name == "__adhoc_playbook__":
             content = cli_options["module_name"]
             if cli_options["module_args"]:
-                content = "{0}: {1}".format(content, cli_options["module_args"])
-            path = "Ad-Hoc: {0}".format(content)
+                content = "{}: {}".format(content, cli_options["module_args"])
+            path = f"Ad-Hoc: {content}"
         else:
             path = os.path.abspath(playbook._file_name)
 
@@ -415,7 +414,7 @@ class CallbackModule(CallbackBase):
             ignored = False
             for ignored_file_pattern in self.ignored_files:
                 if ignored_file_pattern in path:
-                    self.log.debug("Ignoring file {1}, matched pattern: {0}".format(ignored_file_pattern, path))
+                    self.log.debug(f"Ignoring file {path}, matched pattern: {ignored_file_pattern}")
                     ignored = True
                     break
 
@@ -578,14 +577,14 @@ class CallbackModule(CallbackBase):
             for ignored_file_pattern in self.ignored_files:
                 if ignored_file_pattern in path:
                     # The file must be created because there will be things referring to it
-                    self.log.debug("Censoring file {1}, matched pattern: {0}".format(ignored_file_pattern, path))
+                    self.log.debug(f"Censoring file {path}, matched pattern: {ignored_file_pattern}")
                     content = "Not saved by ARA as configured by 'ignored_files'"
             if content is None:
                 try:
-                    with open(path, "r") as fd:
+                    with open(path) as fd:
                         content = fd.read()
-                except IOError as e:
-                    self.log.error("Unable to open {0} for reading: {1}".format(path, str(e)))
+                except OSError as e:
+                    self.log.error(f"Unable to open {path} for reading: {str(e)}")
                     content = """ARA was not able to read this file successfully.
                             Refer to the logs for more information"""
 

--- a/ara/plugins/lookup/ara_api.py
+++ b/ara/plugins/lookup/ara_api.py
@@ -1,13 +1,11 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
 
 from ansible.plugins.lookup import LookupBase
 
 from ara.clients import utils as client_utils
 
-__metaclass__ = type
 
 DOCUMENTATION = """
     lookup: ara_api
@@ -37,7 +35,7 @@ RETURN = """
 
 class LookupModule(LookupBase):
     def __init__(self, *args, **kwargs):
-        super(LookupModule, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.client = client_utils.active_client()
 
     def run(self, terms, variables, **kwargs):

--- a/ara/plugins/lookup/ara_api.py
+++ b/ara/plugins/lookup/ara_api.py
@@ -6,7 +6,6 @@ from ansible.plugins.lookup import LookupBase
 
 from ara.clients import utils as client_utils
 
-
 DOCUMENTATION = """
     lookup: ara_api
     author: David Moreau-Simard (@dmsimard)

--- a/ara/setup/action_plugins.py
+++ b/ara/setup/action_plugins.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import print_function
 
 from . import action_plugins
 

--- a/ara/setup/ansible.py
+++ b/ara/setup/ansible.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import print_function
 
 from . import action_plugins, callback_plugins, lookup_plugins
 

--- a/ara/setup/callback_plugins.py
+++ b/ara/setup/callback_plugins.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import print_function
 
 from . import callback_plugins
 

--- a/ara/setup/env.py
+++ b/ara/setup/env.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import print_function
 
 import os
 from sysconfig import get_path

--- a/ara/setup/lookup_plugins.py
+++ b/ara/setup/lookup_plugins.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import print_function
 
 from . import lookup_plugins
 

--- a/ara/setup/path.py
+++ b/ara/setup/path.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import print_function
 
 from . import path
 

--- a/ara/setup/plugins.py
+++ b/ara/setup/plugins.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import print_function
 
 from . import plugins
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -3,8 +3,10 @@
 
 import os
 import sys
-import sphinx_rtd_theme
+
 import pbr.version
+import sphinx_rtd_theme
+
 version_info = pbr.version.VersionInfo('ara')
 
 sys.path.insert(0, os.path.abspath('../..'))

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,8 +30,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'ara'
-copyright = u'2022, ARA Records Ansible authors'
+project = 'ara'
+copyright = '2022, ARA Records Ansible authors'
 author = 'ARA Records Ansible authors'
 
 # The short X.Y version.
@@ -66,8 +66,8 @@ htmlhelp_basename = '%sdoc' % project
 latex_documents = [
     ('index',
      '%s.tex' % project,
-     u'%s Documentation' % project,
-     u'ARA Records Ansible authors', 'manual'),
+     '%s Documentation' % project,
+     'ARA Records Ansible authors', 'manual'),
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/tests/with_ansible-runner.py
+++ b/tests/with_ansible-runner.py
@@ -5,11 +5,12 @@
 # Example using ara with ansible-runner
 import json
 import os
+
 import ansible_runner
 
 try:
-    from ara.setup import callback_plugins, action_plugins, lookup_plugins
     from ara.clients.utils import get_client
+    from ara.setup import action_plugins, callback_plugins, lookup_plugins
 except ImportError as e:
     print("ara must be installed first: https://github.com/ansible-community/ara#getting-started")
     raise(e)

--- a/tests/with_ansible-runner.py
+++ b/tests/with_ansible-runner.py
@@ -41,7 +41,7 @@ def main():
         playbook=PLAYBOOK,
     )
     playbook_file = os.path.join(os.path.dirname(__file__), ".ara_playbook")
-    with open(playbook_file, "r") as f:
+    with open(playbook_file) as f:
         playbook_id = f.read()
 
     # Retrieve an ara API client


### PR DESCRIPTION
* This PR auto-formats all the code-base to py36+ using `pyupgrade`: https://github.com/asottile/pyupgrade

Command: 
```bash
git clone git@github.com:ansible-community/ara.git
pyupgrade --keep-percent-format --py36-plus *.py */*/*/*/*/*.py
```

* Sorted all imports using `isort`: https://github.com/PyCQA/isort

Command: 
```bash
git clone git@github.com:ansible-community/ara.git
isort .
```

Partially Fixes #420 