### PR TITLE
ui: Add a simple index for the distributed sqlite backend

### DIFF
--- a/ara/server/wsgi.py
+++ b/ara/server/wsgi.py
@@ -52,6 +52,12 @@ def distributed_sqlite(environ, start_response):
     if path_info.startswith(settings.STATIC_URL) or path_info == "/healthcheck/":
         return default_application(environ, start_response)
 
+    # The root of the application should be served by the regular app to show
+    # a distributed database index
+    if path_info == "" or path_info == "/":
+        environ["PATH_INFO"] = "/distributed"
+        return default_application(environ, start_response)
+
     if prefix not in path_info:
         logger.warn("Ignoring request: URL does not contain delegated prefix (%s)" % prefix)
         return handle_404(start_response)

--- a/ara/ui/templates/base.html
+++ b/ara/ui/templates/base.html
@@ -85,6 +85,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarCollapse">
       <ul class="navbar-nav mr-auto">
+        {% if not distributed %}
         <li class="nav-item{% if page == 'index' %} active{% endif %}">
           <a class="nav-link" href="{% static_url index_url %}">Playbooks</a>
         </li>
@@ -98,6 +99,7 @@
           <li class="nav-item">
             {% include "partials/api_link.html" %}
           </li>
+        {% endif %}
         {% endif %}
       </ul>
       <form class="form-inline">

--- a/ara/ui/templates/distributed_index.html
+++ b/ara/ui/templates/distributed_index.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% load strip_db %}
+
+
+{% block title %}| Distributed database index{% endblock %}
+{% block body %}
+
+<div class="alert alert-primary" role="alert">
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
+        <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+        <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
+    </svg>
+    This is ara's <a class="alert-link" href="https://ara.readthedocs.io/en/latest/distributed-sqlite-backend.html" target="_blank">distributed sqlite backend</a> index.
+    It does not have an API but provides links to databases where the reporting UI and API are available.
+</div>
+
+<div>
+    <h4>Database root: {{ distributed_sqlite_root }}</h4>
+    <div class="table-responsive">
+        <table class="table table-sm table-hover" id="distributed_table">
+            <thead>
+                <tr style="height:50px;">
+                    <th title="Path">Path</th>
+                    <th class="text-right" title="Path">Size</th>
+                    <th class="text-right" title="Path">Last updated</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for database in databases %}
+                <tr>
+                    <td><a href="{{ database.path | strip_db }}">{{ database.path }}</a></td>
+                    <td class="text-right">{{ database.size }}</td>
+                    <td class="text-right">{{ database.updated }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+{% endblock %}

--- a/ara/ui/templatetags/strip_db.py
+++ b/ara/ui/templatetags/strip_db.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 The ARA Records Ansible authors
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter(name="strip_db")
+def strip_db(path):
+    """
+    The distributed sqlite backend provides full paths to databases.
+    Return the path to the base directory instead.
+    """
+    return path.replace("/ansible.sqlite", "")

--- a/ara/ui/urls.py
+++ b/ara/ui/urls.py
@@ -9,6 +9,7 @@ from ara.ui import views
 app_name = "ui"
 urlpatterns = [
     path("", views.Index.as_view(), name="index"),
+    path("distributed", views.Distributed.as_view(), name="distributed"),
     path("hosts", views.HostIndex.as_view(), name="host_index"),
     path("tasks", views.TaskIndex.as_view(), name="task_index"),
     path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain")),

--- a/ara/ui/utils.py
+++ b/ara/ui/utils.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2022 The ARA Records Ansible authors
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import glob
+import os
+from datetime import datetime
+
+from django.utils.timezone import make_aware
+
+
+def _human_readable_timestamp(seconds):
+    """
+    Translates a unix timestamp in seconds into something human readable.
+    """
+    timestamp = make_aware(datetime.fromtimestamp(seconds))
+    return timestamp.strftime("%d %b %Y %H:%M:%S %z")
+
+
+def _human_readable_size(size, decimal_places=2):
+    """
+    Translates a number of bytes from os.stat into something human readable.
+    """
+    for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
+        if size < 1024.0:
+            break
+        size /= 1024.0
+    return f"{size:.{decimal_places}f}{unit}"
+
+
+def find_distributed_databases(distributed_sqlite_root):
+    """
+    TODO: This approach can be slow, especially at scale if there are a lot of directories to look into.
+          We should find a way to prevent crawling the filesystem each time, perhaps by doing it once and
+          caching the results.
+    """
+    databases = glob.glob(f"{distributed_sqlite_root}/**/ansible.sqlite", recursive=True)
+    data = []
+    for db in databases:
+        stat = os.stat(db)
+        data.append(
+            {
+                "path": db.replace(f"{distributed_sqlite_root}/", ""),
+                "size": _human_readable_size(stat.st_size),
+                "updated": _human_readable_timestamp(stat.st_mtime),
+            }
+        )
+
+    return data


### PR DESCRIPTION
The index when using the distributed sqlite backend was a 404 not found which isn't very helpful.

Add a simple (but useful) index that contains a list of databases and we can improve it later.