### PR TITLE
zuul: add tests for 2.14 and update to 6.4.0

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -120,7 +120,16 @@
       Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible 6 (ansible-core 2.13).
     vars:
       ara_tests_ansible_name: ansible
-      ara_tests_ansible_version: 6.1.0
+      ara_tests_ansible_version: 6.4.0
+
+- job:
+    name: ara-basic-ansible-core-2.14
+    parent: ara-ansible-integration-base
+    description: |
+      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible-core 2.14.
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.14
 
 - job:
     name: ara-basic-ansible-core-2.13

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -8,6 +8,7 @@
         - ara-basic-ansible-core-devel:
             voting: false
         - ara-basic-ansible-6
+        - ara-basic-ansible-core-2.14
         - ara-basic-ansible-core-2.13
         - ara-basic-ansible-core-2.12
         - ara-basic-ansible-core-2.11
@@ -19,6 +20,7 @@
         - ara-tox-linters
         - ara-tox-docs
         - ara-basic-ansible-6
+        - ara-basic-ansible-core-2.14
         - ara-basic-ansible-core-2.13
         - ara-basic-ansible-core-2.12
         - ara-basic-ansible-core-2.11
@@ -28,4 +30,3 @@
       jobs:
         - ara-container-images-dockerhub
         - ara-container-images-quayio
-


### PR DESCRIPTION
- 2.14 hasn't been released yet but they have branched and it'll be out soon.
- Bump ansible to 6.4.0 while 7.0.0 is in alpha