### PR TITLE
setup.py: Declare the readme as markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,4 @@
 
 import setuptools
 
-setuptools.setup(setup_requires=["pbr"], pbr=True)
+setuptools.setup(setup_requires=["pbr"], pbr=True, long_description_content_type="text/markdown")


### PR DESCRIPTION
PyPI defaults to rst and we've changed the README to markdown since 1.5.8.

For reference: https://pypi.org/help/#description-content-type