### PR TITLE
Use package extras consistently.

### DIFF
--- a/contrib/container-images/centos-pypi.sh
+++ b/contrib/container-images/centos-pypi.sh
@@ -15,7 +15,7 @@ buildah run "${build}" -- dnf install -y ${DEV_DEPENDENCIES}
 
 # Install ara from PyPI with API server extras for dependencies (django & django-rest-framework)
 # including database backend libraries and gunicorn
-buildah run "${build}" -- python3 -m pip install "ara[server]" "psycopg2<2.9" mysqlclient gunicorn
+buildah run "${build}" -- python3 -m pip install "ara[server,postgresql,mysql]" gunicorn
 
 # Remove development dependencies and clean up
 buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all && python3 -m pip cache purge"

--- a/contrib/container-images/centos-source.sh
+++ b/contrib/container-images/centos-source.sh
@@ -24,7 +24,7 @@ buildah run "${build}" -- dnf install -y ${DEV_DEPENDENCIES}
 
 # Install ara from source with API server extras for dependencies (django & django-rest-framework)
 # including database backend libraries and gunicorn
-buildah run --volume ${SOURCE_DIR}:/usr/local/src/ara:z "${build}" -- python3 -m pip install "/usr/local/src/ara/${sdist}[server]" psycopg2 mysqlclient gunicorn
+buildah run --volume ${SOURCE_DIR}:/usr/local/src/ara:z "${build}" -- python3 -m pip install "/usr/local/src/ara/${sdist}[server,postgresql,mysql]" gunicorn
 
 # Remove development dependencies and clean up
 buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all && python3 -m pip cache purge"

--- a/contrib/container-images/fedora-pypi.sh
+++ b/contrib/container-images/fedora-pypi.sh
@@ -14,7 +14,7 @@ buildah run "${build}" -- dnf install -y ${DEV_DEPENDENCIES}
 
 # Install ara from PyPI with API server extras for dependencies (django & django-rest-framework)
 # including database backend libraries and gunicorn
-buildah run "${build}" -- python3 -m pip install "ara[server]" "psycopg2<2.9" mysqlclient gunicorn
+buildah run "${build}" -- python3 -m pip install "ara[server,postgresql,mysql]" gunicorn
 
 # Remove development dependencies and clean up
 buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all && python3 -m pip cache purge"

--- a/contrib/container-images/fedora-source.sh
+++ b/contrib/container-images/fedora-source.sh
@@ -24,7 +24,7 @@ buildah run "${build}" -- dnf install -y ${DEV_DEPENDENCIES}
 
 # Install ara from source with API server extras for dependencies (django & django-rest-framework)
 # including database backend libraries and gunicorn
-buildah run --volume ${SOURCE_DIR}:/usr/local/src/ara:z "${build}" -- python3 -m pip install "/usr/local/src/ara/${sdist}[server]" psycopg2 mysqlclient gunicorn
+buildah run --volume ${SOURCE_DIR}:/usr/local/src/ara:z "${build}" -- python3 -m pip install "/usr/local/src/ara/${sdist}[server,postgresql,mysql]" gunicorn
 
 # Remove development dependencies and clean up
 buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf autoremove -y && dnf clean all && python3 -m pip cache purge"

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,8 @@ server=
     pygments
 postgresql=
     psycopg2
+mysql=
+    mysqlclient
 
 [build_sphinx]
 source-dir = doc/source


### PR DESCRIPTION
Not sure if there was a reason to limit psycopg2 to < 2.9. If there is, we could limit globally in setup.cfg now as well.