### PR TITLE
Nonblocking callback

### DIFF
--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -853,7 +853,7 @@ class CallbackModule(CallbackBase):
         self.queue = Queue()
         # started at the end of set_options()
         self.worker = AraWorker(queue=self.queue)
-        self.worker_thread = threading.Thread(target=self.worker.run)
+        self.worker_thread = threading.Thread(target=self.worker.run, daemon=True)
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
         super().set_options(task_keys=task_keys, var_options=var_options, direct=direct)

--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -432,7 +432,10 @@ class AraWorker:
             self._submit_thread("global", self._set_playbook_labels, labels)
 
         # Record all the files involved in the play
-        for path in play._loader._FILE_CACHE.keys():
+        #   make a list of the keys and iterate that for thread safety
+        #   avoiding `RuntimeError: dictionary changed size during iteration`
+        play_files = list(play._loader._FILE_CACHE.keys())
+        for path in play_files:
             # The cache can be pre-populated with files that aren't relevant to the playbook report
             # If there are matches that should be ignored here, don't record them at all
             ignored = False

--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -855,14 +855,6 @@ class CallbackModule(CallbackBase):
         self.worker = AraWorker(queue=self.queue)
         self.worker_thread = threading.Thread(target=self.worker.run)
 
-    def __del__(self):
-        """
-        Give the thread as long as possible to complete its work.
-        """
-        self.queue.join()
-        if self.worker_thread.is_alive():
-            self.worker_thread.join()
-
     def set_options(self, task_keys=None, var_options=None, direct=None):
         super().set_options(task_keys=task_keys, var_options=var_options, direct=direct)
 


### PR DESCRIPTION
This PR makes it so that the ARA callback module no longer blocks the flow of Ansible playbook execution at all. Now the only blocking happens for the requests sent at the end of the playbook (this is unavoidable). This is accomplished by moving all logic for the callback to a separate thread and pushing received callback messages to the worker thread via a queue.

I ran some very simple benchmarks to confirm that this does in fact improve performance. I would like to have more robust measurements, but right now these are what I had time for.

All measurements were taken with 10 hosts performing 5 tasks across 10 forks. Times are reported in milliseconds and averaged over 5 runs.

First, the test used in [the ARA benchmark article](https://ara.recordsansible.org/blog/2020/11/01/benchmarking-ansible-and-ara-for-fun-and-science/) - each task is just `debug`
|strat|  client|  db|       threads| master| nonblock| diff|
|------| -------| --------| -------| ------| --------| ----- |
|free| | | |                              984| | |
|linear| | | |                            1042| | |
|linear| http|    sqlite|   0|       2628|   2380|     -248|
|free|   http|    sqlite|   0|       3588|   3073|     -515|
|free|   http|    postgres| 4|       4463|   3888|     -575|
|linear| http|    postgres| 0|       4847|   4267|     -580|
|linear| offline| postgres| 4|       4892|   4722|     -170|
|free|   http|    postgres| 0|       7194|   6244|     -950|
|linear| offline| sqlite|   0|       8026|   7426|     -600|
|linear| offline| postgres| 0|       8262|   7487|     -775|
|free|   offline| postgres| 4|       8771|   8039|     -732|
|free|   offline| sqlite|   0|       11835|  10850|    -985|
|free|   offline| postgres| 0|       11939|  10771|    -1168

The second test used the `ansible.builtin.shell` module to sleep for 1 - 3 seconds in order to mimic more realistic conditions
|strat|  client|  db|       threads| master| nonblock| diff|
|------| -------| --------| -------| ------| --------| ----- |
|free| | | |                              15641| | |
|free|   http|    postgres| 4|       15704|  16150|    446| 
|free|   http|    sqlite|   0|       16221|  14842|    -1379 |
|linear| | | |                            18190| | |
|free|   offline| postgres| 4|       18353|  15907|    -2446 |
|free|   http|    postgres| 0|       18454|  15572|    -2882 |
|linear| http|    sqlite|   0|       19229|  18668|    -561|
|free|   offline| sqlite|   0|       19590|  17511|    -2079 |
|linear| http|    postgres| 4|       19919|  19405|    -514|
|free|   offline| postgres| 0|       20170|  16072|    -4098 |
|linear| http|    postgres| 0|       20595|  19226|    -1369 |
|linear| offline| postgres| 4|       20849|  19746|    -1103 |
|linear| offline| postgres| 0|       22578|  20276|    -2302 |
|linear| offline| sqlite|   0|       23304|  19960|    -3344 |

The nonblocking client is faster than the current ARA master branch, and, importantly, makes a big performance difference in the situations where the previous threading-patch cannot help ( using sqlite as the database backend).