### PR TITLE
tests: make it easier to run with_container_images.yml locally

### DIFF
--- a/tests/container_test_tasks.yaml
+++ b/tests/container_test_tasks.yaml
@@ -9,12 +9,19 @@
     recurse: yes
 
 - name: "Build {{ item.name }}:{{ item.tag }} with {{ item.script }}"
-  command: "{{ ara_api_source }}/contrib/container-images/{{ item.script }} {{ item.name }}:{{ item.tag }}"
+  vars:
+    # Assuming running from checked out source
+    # This is done here instead of the play vars because Zuul uses this var and passes it to the playbook as an inventory var
+    # which has less precedence than play vars.
+    # https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence
+    _default_source: "{{ playbook_dir | dirname }}"
+  command: "{{ ara_api_source | default(_default_source) }}/contrib/container-images/{{ item.script }} {{ item.name }}:{{ item.tag }}"
 
 - name: "Start {{ item.name }}:{{ item.tag }} with podman"
   command: |
     podman run --name api-server --detach --tty \
-    --volume {{ ara_api_root_dir }}/server:/opt/ara:z -p 8000:8000 \
+    --volume {{ ara_api_root_dir }}/server:/opt/ara \
+    -p 8000:8000 \
     -e ARA_LOG_LEVEL=DEBUG -e ARA_DEBUG=true \
     {{ item.name }}:{{ item.tag }}
 

--- a/tests/with_container_images.yaml
+++ b/tests/with_container_images.yaml
@@ -4,10 +4,12 @@
 
 - name: Test container images
   hosts: all
-  gather_facts: true
   vars:
+    required_test_packages:
+      - git
+      - buildah
+      - podman
     ara_api_root_dir: "{{ ansible_user_dir }}/.ara-tests"
-    ara_api_source: "{{ ansible_user_dir }}/src/github.com/ansible-community/ara"
     images:
       # These are in chronological order of release so that we don't end up
       # running SQL migrations backwards during the tests.
@@ -27,14 +29,40 @@
         script: fedora-distribution.sh
         name: localhost/ara-api
   tasks:
-    - name: Install git, buildah and podman
+    - name: Get necessary facts
+      ansible.builtin.setup:
+        filter:
+          - date_time
+          - distribution
+          - os_family
+          - python
+          - user_dir
+
+    - name: Get list of installed packages
+      package_facts:
+        manager: "auto"
+      no_log: true
+
+    - name: Retrieve list of missing required packages
+      set_fact:
+        _missing_packages: "{{ required_test_packages | difference(ansible_facts['packages'].keys()) }}"
+
+    # Only attempt to elevate privileges if there are any missing packages
+    # This lets us run this playbook without requiring elevated privileges
+    - when: _missing_packages | length > 0
       become: true
-      package:
-        name:
-          - git
-          - buildah
-          - podman
-        state: present
+      block:
+        - name: Install required packages
+          package:
+            name: "{{ required_test_packages }}"
+            state: present
+      rescue:
+        - name: Fail due to missing packages
+          fail:
+            msg: |
+              Failed to elevate privileges and install missing required packages.
+              Install the following packages before running this playbook again:
+              {{ _missing_packages | join(' ') }}
 
     # TODO: Troubleshoot permission denied issues when running
     #       ara-manage generate from container


### PR DESCRIPTION
- Make the default ara_api_source compatible whether it's running locally or from Zuul
- Only gather the facts we need
- Don't try to elevate privileges if we don't need to
- Don't assume running with selinux (this can be tested elsewhere)