### PR TITLE
ui: truncate long controller hostnames

### DIFF
--- a/ara/ui/templates/index.html
+++ b/ara/ui/templates/index.html
@@ -201,9 +201,9 @@
             </td>
             <td class="text-center">
               {% if not static_generation %}
-                <a href="{% url 'ui:index' %}?controller={{ playbook.controller }}" title="Search for controller {{ playbook.controller }}">{{ playbook.controller | default_if_none:'' }}</a>
+                <a href="{% url 'ui:index' %}?controller={{ playbook.controller }}" title="Search for controller {{ playbook.controller }}">{{ playbook.controller | default_if_none:'' | truncatechars:50 }}</a>
               {% else %}
-                {{ playbook.controller | default_if_none:'' }}
+                {{ playbook.controller | default_if_none:'' | truncatechars:50 }}
               {% endif %}
             </td>
             <td>


### PR DESCRIPTION
Fields that can be very long are generally truncated in tables with the full version available on mouse-over.

This is a compromise to avoid a single column taking up most of the width available in the table.

controller hostnames can be up to 255 characters so truncate them like we do elsewhere.