### PR TITLE
Update versions, integration tests and container images

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -2,21 +2,21 @@
 - job:
     name: ara-tox-py3
     parent: tox
-    nodeset: ara-fedora-36
+    nodeset: ara-fedora-38
     vars:
       tox_envlist: py3
 
 - job:
     name: ara-tox-linters
     parent: tox
-    nodeset: ara-fedora-36
+    nodeset: ara-fedora-38
     vars:
       tox_envlist: linters
 
 - job:
     name: ara-tox-docs
     parent: base
-    nodeset: ara-fedora-36
+    nodeset: ara-fedora-38
     files:
       - doc/*
     run: tests/zuul_docs.yaml
@@ -45,7 +45,7 @@
 - job:
     name: ara-integration-container-base
     parent: ara-integration-base
-    nodeset: ara-fedora-36
+    nodeset: ara-fedora-38
     files:
       - ara/*
       - manage.py
@@ -114,13 +114,22 @@
         override-checkout: devel
 
 - job:
-    name: ara-basic-ansible-6
+    name: ara-basic-ansible-8
     parent: ara-ansible-integration-base
     description: |
-      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible 6 (ansible-core 2.13).
+      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible 8 (ansible-core 2.15).
     vars:
       ara_tests_ansible_name: ansible
-      ara_tests_ansible_version: 6.4.0
+      ara_tests_ansible_version: 8.1.0
+
+- job:
+    name: ara-basic-ansible-core-2.15
+    parent: ara-ansible-integration-base
+    description: |
+      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible-core 2.15.
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.15
 
 - job:
     name: ara-basic-ansible-core-2.14
@@ -130,33 +139,6 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.14
-
-- job:
-    name: ara-basic-ansible-core-2.13
-    parent: ara-ansible-integration-base
-    description: |
-      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible-core 2.13.
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.13
-
-- job:
-    name: ara-basic-ansible-core-2.12
-    parent: ara-ansible-integration-base
-    description: |
-      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible-core 2.12.
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.12
-
-- job:
-    name: ara-basic-ansible-core-2.11
-    parent: ara-ansible-integration-base
-    description: |
-      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible-core 2.11.
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
 
 - job:
     name: ara-basic-ansible-2.9

--- a/.zuul.d/nodesets.yaml
+++ b/.zuul.d/nodesets.yaml
@@ -2,7 +2,7 @@
     name: ara-basic-nodeset
     nodes:
       - name: ara-api-server
-        label: ansible-cloud-fedora-36-tiny
+        label: ansible-cloud-fedora-38-tiny
     # or if testing multiple OS simultaneously:
     # groups:
     #  - name: ara-api-server
@@ -10,3 +10,13 @@
     #      - fedora-35-1vcpu
     #      - centos-8-stream
     #      - ubuntu-bionic-1vcpu
+
+- nodeset:
+    name: ara-fedora-38
+    nodes:
+      - name: fedora-38
+        label: ansible-cloud-fedora-38-tiny
+    groups:
+      - name: ara-api-server
+        nodes:
+          - fedora-38

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -7,11 +7,9 @@
         - ara-tox-docs
         - ara-basic-ansible-core-devel:
             voting: false
-        - ara-basic-ansible-6
+        - ara-basic-ansible-8
+        - ara-basic-ansible-core-2.15
         - ara-basic-ansible-core-2.14
-        - ara-basic-ansible-core-2.13
-        - ara-basic-ansible-core-2.12
-        - ara-basic-ansible-core-2.11
         - ara-basic-ansible-2.9
         - ara-container-images
     gate:
@@ -19,11 +17,9 @@
         - ara-tox-py3
         - ara-tox-linters
         - ara-tox-docs
-        - ara-basic-ansible-6
+        - ara-basic-ansible-8
+        - ara-basic-ansible-core-2.15
         - ara-basic-ansible-core-2.14
-        - ara-basic-ansible-core-2.13
-        - ara-basic-ansible-core-2.12
-        - ara-basic-ansible-core-2.11
         - ara-basic-ansible-2.9
         - ara-container-images
     post:

--- a/contrib/container-images/README.rst
+++ b/contrib/container-images/README.rst
@@ -27,10 +27,10 @@ You will need to install `buildah <https://github.com/containers/buildah/blob/ma
 
 The different scripts to build container images are available in the git repository:
 
-- fedora-distribution.sh_: Builds an image from Fedora 36 `distribution packages <https://koji.fedoraproject.org/koji/packageinfo?packageID=24394>`_
-- fedora-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on Fedora 36
-- fedora-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on Fedora 36
-- centos-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on CentOS 8 Stream
+- fedora-distribution.sh_: Builds an image from Fedora 38 `distribution packages <https://koji.fedoraproject.org/koji/packageinfo?packageID=24394>`_
+- fedora-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on Fedora 38
+- fedora-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on Fedora 38
+- centos-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on CentOS 9 Stream
 - centos-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on CentOS 9 Stream
 
 .. _fedora-distribution.sh: https://github.com/ansible-community/ara/blob/master/contrib/container-images/fedora-distribution.sh

--- a/contrib/container-images/centos-pypi.sh
+++ b/contrib/container-images/centos-pypi.sh
@@ -5,7 +5,7 @@ DEV_DEPENDENCIES="gcc python3-devel postgresql-devel mariadb-connector-c-devel"
 
 # Builds an ARA API server container image using the latest PyPi packages on CentOS Stream 8.
 # TODO: update to stream9 once 1.6.0 is released https://github.com/ansible-community/ara/issues/401
-build=$(buildah from quay.io/centos/centos:stream8)
+build=$(buildah from quay.io/centos/centos:stream9)
 
 # Ensure everything is up to date and install requirements
 buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-pip-wheel postgresql libpq mariadb-connector-c"

--- a/contrib/container-images/fedora-distribution.sh
+++ b/contrib/container-images/fedora-distribution.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -x
-# Copyright (c) 2022 The ARA Records Ansible authors
+# Copyright (c) 2023 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Builds an ARA API server container image from Fedora 36 distribution packages.
-build=$(buildah from quay.io/fedora/fedora:36)
+# Builds an ARA API server container image from Fedora 38 distribution packages.
+build=$(buildah from quay.io/fedora/fedora:38)
 
 # Get all updates, install the ARA API server, database backends and gunicorn application server
 # This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.

--- a/contrib/container-images/fedora-pypi.sh
+++ b/contrib/container-images/fedora-pypi.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -x
-# Copyright (c) 2022 The ARA Records Ansible authors
+# Copyright (c) 2023 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 DEV_DEPENDENCIES="gcc python3-devel postgresql-devel mariadb-devel"
 
 # Builds an ARA API server container image using the latest PyPi packages on Fedora 36.
-build=$(buildah from quay.io/fedora/fedora:36)
+build=$(buildah from quay.io/fedora/fedora:38)
 
 # Ensure everything is up to date and install requirements
 buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-wheel postgresql libpq mariadb-connector-c"

--- a/contrib/container-images/fedora-source.sh
+++ b/contrib/container-images/fedora-source.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -x
-# Copyright (c) 2022 The ARA Records Ansible authors
+# Copyright (c) 2023 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 DEV_DEPENDENCIES="gcc python3-devel postgresql-devel mariadb-devel"
 
@@ -14,7 +14,7 @@ python3 setup.py sdist
 sdist=$(ls dist/ara-*.tar.gz)
 popd
 
-build=$(buildah from quay.io/fedora/fedora:36)
+build=$(buildah from quay.io/fedora/fedora:38)
 
 # Ensure everything is up to date and install requirements
 buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-wheel postgresql libpq mariadb-connector-c"

--- a/tests/container_test_tasks.yaml
+++ b/tests/container_test_tasks.yaml
@@ -9,12 +9,19 @@
     recurse: yes
 
 - name: "Build {{ item.name }}:{{ item.tag }} with {{ item.script }}"
-  command: "{{ ara_api_source }}/contrib/container-images/{{ item.script }} {{ item.name }}:{{ item.tag }}"
+  vars:
+    # Assuming running from checked out source
+    # This is done here instead of the play vars because Zuul uses this var and passes it to the playbook as an inventory var
+    # which has less precedence than play vars.
+    # https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence
+    _default_source: "{{ playbook_dir | dirname }}"
+  command: "{{ ara_api_source | default(_default_source) }}/contrib/container-images/{{ item.script }} {{ item.name }}:{{ item.tag }}"
 
 - name: "Start {{ item.name }}:{{ item.tag }} with podman"
   command: |
     podman run --name api-server --detach --tty \
-    --volume {{ ara_api_root_dir }}/server:/opt/ara:z -p 8000:8000 \
+    --volume {{ ara_api_root_dir }}/server:/opt/ara \
+    -p 8000:8000 \
     -e ARA_LOG_LEVEL=DEBUG -e ARA_DEBUG=true \
     {{ item.name }}:{{ item.tag }}
 

--- a/tests/with_container_images.yaml
+++ b/tests/with_container_images.yaml
@@ -11,19 +11,19 @@
     images:
       # These are in chronological order of release so that we don't end up
       # running SQL migrations backwards during the tests.
-      - tag: fedora36-source-latest
+      - tag: fedora38-source-latest
         script: fedora-source.sh
         name: localhost/ara-api
       - tag: centos9-source-latest
         script: centos-source.sh
         name: localhost/ara-api
-      - tag: fedora36-pypi-latest
+      - tag: fedora38-pypi-latest
         script: fedora-pypi.sh
         name: localhost/ara-api
-      - tag: centos8-pypi-latest
+      - tag: centos9-pypi-latest
         script: centos-pypi.sh
         name: localhost/ara-api
-      - tag: fedora36-distribution-latest
+      - tag: fedora38-distribution-latest
         script: fedora-distribution.sh
         name: localhost/ara-api
   tasks:

--- a/tests/with_container_images.yaml
+++ b/tests/with_container_images.yaml
@@ -4,10 +4,12 @@
 
 - name: Test container images
   hosts: all
-  gather_facts: true
   vars:
+    required_test_packages:
+      - git
+      - buildah
+      - podman
     ara_api_root_dir: "{{ ansible_user_dir }}/.ara-tests"
-    ara_api_source: "{{ ansible_user_dir }}/src/github.com/ansible-community/ara"
     images:
       # These are in chronological order of release so that we don't end up
       # running SQL migrations backwards during the tests.
@@ -27,17 +29,43 @@
         script: fedora-distribution.sh
         name: localhost/ara-api
   tasks:
-    - name: Install git, buildah and podman
-      become: true
-      package:
-        name:
-          - git
-          - buildah
-          - podman
-        state: present
+    - name: Get necessary facts
+      ansible.builtin.setup:
+        filter:
+          - date_time
+          - distribution
+          - os_family
+          - python
+          - user_dir
 
-    # TODO: Troubleshoot permission denied issues when running
-    #       ara-manage generate from container
+    - name: Get list of installed packages
+      package_facts:
+        manager: "auto"
+      no_log: true
+
+    - name: Retrieve list of missing required packages
+      set_fact:
+        _missing_packages: "{{ required_test_packages | difference(ansible_facts['packages'].keys()) }}"
+
+    # Only attempt to elevate privileges if there are any missing packages
+    # This lets us run this playbook without requiring elevated privileges
+    - when: _missing_packages | length > 0
+      become: true
+      block:
+        - name: Install required packages
+          package:
+            name: "{{ required_test_packages }}"
+            state: present
+      rescue:
+        - name: Fail due to missing packages
+          fail:
+            msg: |
+              Failed to elevate privileges and install missing required packages.
+              Install the following packages before running this playbook again:
+              {{ _missing_packages | join(' ') }}
+
+    # TODO: https://github.com/containers/podman/issues/11109
+    # bash: error while loading shared libraries: /lib64/libc.so.6: cannot apply additional memory protection after relocation: Permission denied
     - when: ansible_os_family == "RedHat"
       become: true
       block:

--- a/tests/zuul_publish_container_images.yaml
+++ b/tests/zuul_publish_container_images.yaml
@@ -8,15 +8,15 @@
     destination: "{{ destination_repository | default('docker.io/recordsansible/ara-api') }}"
     images:
       # These images are meant to be provided by the "with_container_images.yaml" playbook
-      - tag: fedora36-source-latest
+      - tag: fedora38-source-latest
         name: localhost/ara-api
       - tag: centos9-source-latest
         name: localhost/ara-api
-      - tag: fedora36-pypi-latest
+      - tag: fedora38-pypi-latest
         name: localhost/ara-api
-      - tag: centos8-pypi-latest
+      - tag: centos9-pypi-latest
         name: localhost/ara-api
-      - tag: fedora36-distribution-latest
+      - tag: fedora38-distribution-latest
         name: localhost/ara-api
   tasks:
     - name: List built container images
@@ -28,9 +28,9 @@
         buildah tag {{ item.name }}:{{ item.tag }} {{ destination }}:{{ item.tag }}
       loop: "{{ images }}"
 
-    - name: Tag latest from fedora36-pypi-latest
+    - name: Tag latest from fedora38-pypi-latest
       command: |
-        buildah tag {{ destination }}:fedora36-pypi-latest {{ destination }}:latest
+        buildah tag {{ destination }}:fedora38-pypi-latest {{ destination }}:latest
 
     - name: Push latest
       command: |

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ setenv =
   ARA_BASE_DIR={env:ARA_BASE_DIR:{envtmpdir}}
 
 [testenv:linters]
+allowlist_externals = {toxinidir}/tests/linters.sh
 commands = {toxinidir}/tests/linters.sh
 
 [testenv:py3]


### PR DESCRIPTION
The container images and CI tests had gone a bit stale in the time I was away.

- containers: updated fedora base image from 36 to 38
- containers: updated centos-pypi image from stream8 to stream9
- zuul: Update fedora base image from 36 to 38
- zuul: Update ansible version tested from 6.4.0 to 8.1.0
- zuul: Update versions of ansible-core tested (2.9, 2.14, 2.15)