### PR TITLE
maintenance: Bump version of django from 3.2LTS to 4.2LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ara provides Ansible reporting by recording ``ansible`` and ``ansible-playbook``
 - from a terminal, by hand or from a script
 - from a laptop, desktop, server, VM or container
 - for development, CI or production
-- from most Linux distributions and even on Mac OS (as long as ``python >= 3.6`` is available)
+- from most Linux distributions and even on Mac OS (as long as ``python >= 3.8`` is available)
 - from tools that run playbooks such as AWX & Automation Controller (Tower), ansible-(pull|test|runner|navigator) and Molecule
 - from CI/CD platforms such as Jenkins, GitHub Actions, GitLab CI, Rundeck and Zuul
 
@@ -35,7 +35,7 @@ The callback plugin leverages built-in python API clients to send data to a REST
 
 ## Requirements
 
-- Any recent Linux distribution or Mac OS with python >=3.6 available
+- Any recent Linux distribution or Mac OS with python >=3.8 available
 - The ara package (containing the Ansible plugins) must be installed for the same python interpreter as Ansible itself
 
 ## Getting started

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,14 +14,15 @@ classifier =
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Development Status :: 5 - Production/Stable
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.8
 
 [global]
 setup-hooks =
@@ -63,18 +64,16 @@ ara.cli =
 
 [extras]
 server=
-    Django>=3.2,<3.3
+    Django>=4.2,<4.3
     djangorestframework>=3.9.1
     django-cors-headers
     django-filter
     django-health-check
     # dynaconf 3.1.3 had a regression https://github.com/ansible-community/ara/issues/212
     # dynaconf dropped support for py35 at version 3.0.0: https://github.com/ansible-community/ara/issues/370
-    dynaconf[yaml]>=3.0.0,!=3.1.3,<4.0.0;python_version>='3.6'
+    dynaconf[yaml]>=3.0.0,!=3.1.3,<4.0.0
     tzlocal>=4.0
-    # whitenoise 6.0.0 dropped support for py36
-    whitenoise<6.0.0;python_version=='3.6'
-    whitenoise;python_version>='3.7'
+    whitenoise
     pygments
 postgresql=
     psycopg2


### PR DESCRIPTION
See: https://github.com/ansible-community/ara/issues/485

Django 4.2LTS was released in April 2023 and 3.2LTS will be supported until April 2024: https://docs.djangoproject.com/en/4.2/releases/4.2/

Django 4.2 raises the Python requirement from 3.6 up to 3.8 so in effect it means we are also raising the requirement for ara itself.

Given the change in requirements, this will warrant a version bump for ara from 1.6.1 to 1.7.0.