### PR TITLE
docs: update links to use django 4.2

### DIFF
--- a/doc/source/api-configuration.rst
+++ b/doc/source/api-configuration.rst
@@ -8,7 +8,7 @@ environments (*such as dev, staging, prod*) and allows you to customize the
 configuration with files, environment variables or a combination of both.
 
 The API is a Django application that leverages django-rest-framework.
-Both `Django <https://docs.djangoproject.com/en/3.2/ref/settings/>`_ and
+Both `Django <https://docs.djangoproject.com/en/4.2/ref/settings/>`_ and
 `django-rest-framework <https://www.django-rest-framework.org/api-guide/settings/>`_
 have extensive configuration options which are not necessarily exposed or made
 customizable by ARA for the sake of simplicity.
@@ -81,19 +81,19 @@ For more details, click on the configuration parameters.
 
 .. _CORS_ORIGIN_WHITELIST: https://github.com/adamchainz/django-cors-headers#cors_origin_whitelist
 .. _CORS_ORIGIN_REGEX_WHITELIST: https://github.com/adamchainz/django-cors-headers#cors_origin_regex_whitelist
-.. _CSRF_TRUSTED_ORIGINS: https://docs.djangoproject.com/en/3.2/ref/settings/#csrf-trusted-origins
-.. _ALLOWED_HOSTS: https://docs.djangoproject.com/en/3.2/ref/settings/#allowed-hosts
-.. _DEBUG: https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-DEBUG
-.. _SECRET_KEY: https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-SECRET_KEY
-.. _TIME_ZONE: https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-TIME_ZONE
-.. _ENGINE: https://docs.djangoproject.com/en/3.2/ref/settings/#engine
-.. _NAME: https://docs.djangoproject.com/en/3.2/ref/settings/#name
-.. _USER: https://docs.djangoproject.com/en/3.2/ref/settings/#user
-.. _PASSWORD: https://docs.djangoproject.com/en/3.2/ref/settings/#password
-.. _HOST: https://docs.djangoproject.com/en/3.2/ref/settings/#host
-.. _PORT: https://docs.djangoproject.com/en/3.2/ref/settings/#port
-.. _CONN_MAX_AGE: https://docs.djangoproject.com/en/3.2/ref/settings/#conn-max-age
-.. _OPTIONS: https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-OPTIONS
+.. _CSRF_TRUSTED_ORIGINS: https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins
+.. _ALLOWED_HOSTS: https://docs.djangoproject.com/en/4.2/ref/settings/#allowed-hosts
+.. _DEBUG: https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-DEBUG
+.. _SECRET_KEY: https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-SECRET_KEY
+.. _TIME_ZONE: https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-TIME_ZONE
+.. _ENGINE: https://docs.djangoproject.com/en/4.2/ref/settings/#engine
+.. _NAME: https://docs.djangoproject.com/en/4.2/ref/settings/#name
+.. _USER: https://docs.djangoproject.com/en/4.2/ref/settings/#user
+.. _PASSWORD: https://docs.djangoproject.com/en/4.2/ref/settings/#password
+.. _HOST: https://docs.djangoproject.com/en/4.2/ref/settings/#host
+.. _PORT: https://docs.djangoproject.com/en/4.2/ref/settings/#port
+.. _CONN_MAX_AGE: https://docs.djangoproject.com/en/4.2/ref/settings/#conn-max-age
+.. _OPTIONS: https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-OPTIONS
 
 Configuration variables
 -----------------------


### PR DESCRIPTION
We've updated to django 4.2 in 4144916fd3167aabfd2daac538bef0d937f94776, we should also update the links in the documentation.