### PR TITLE
callback: add tests for ARA_RECORD_* settings

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -139,11 +139,3 @@
       - name: github.com/ansible/ansible
         override-checkout: stable-2.14
 
-- job:
-    name: ara-basic-ansible-2.9
-    parent: ara-ansible-integration-base
-    description: |
-      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with Ansible 2.9.
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -10,7 +10,6 @@
         - ara-basic-ansible-8
         - ara-basic-ansible-core-2.15
         - ara-basic-ansible-core-2.14
-        - ara-basic-ansible-2.9
         - ara-container-images
     gate:
       jobs:
@@ -20,7 +19,6 @@
         - ara-basic-ansible-8
         - ara-basic-ansible-core-2.15
         - ara-basic-ansible-core-2.14
-        - ara-basic-ansible-2.9
         - ara-container-images
     post:
       jobs:

--- a/tests/basic.yaml
+++ b/tests/basic.yaml
@@ -193,6 +193,13 @@
             ARA_LOCALHOST_AS_HOSTNAME: "{{ ara_localhost_as_hostname | default(true) }}"
           command: "ansible-playbook -vvv {{ _test_root }}/lookups.yaml"
 
+        - name: Run record settings tests
+          environment:
+            ARA_RECORD_USER_NAME: "test-user"
+            ARA_RECORD_CONTROLLER_NAME: "test-controller"
+            ARA_RECORD_TASK_CONTENT: "false"
+          command: "ansible-playbook -vvv {{ _test_root }}/record_settings.yaml"
+
         - name: Run delegate_to integration tests
           command: "ansible-playbook -vvv {{ _test_root }}/delegate_to.yaml"
 

--- a/tests/integration/lookups.yaml
+++ b/tests/integration/lookups.yaml
@@ -37,6 +37,8 @@
           - playbook.name == 'ARA self tests'
           - "playbook.labels | selectattr('name', 'search', 'lookup-tests') | list | length == 1"
           - playbook.ansible_version == ansible_version.full
+          - playbook.controller == lookup('pipe', 'hostname')
+          - playbook.user == ansible_facts['user_id']
           - playbook_dir in playbook.path
           - "'tests/integration/lookups.yaml' in playbook.path"
 

--- a/tests/integration/record_settings.yaml
+++ b/tests/integration/record_settings.yaml
@@ -1,0 +1,49 @@
+---
+# Copyright (c) 2023 The ARA Records Ansible authors
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# This tests the behavior when these settings are enabled and so it expects them set as:
+# ARA_RECORD_USER_NAME=test-user (to manually override the recorded user for a playbook)
+# ARA_RECORD_CONTROLLER_NAME=test-controller (to manually override the recorded controller for a playbook)
+# ARA_RECORD_TASK_CONTENT=false (to prevent ara from recording task content)
+
+- name: Validate recording settings
+  hosts: localhost
+  gather_facts: yes
+  vars:
+    ara_playbook_name: ARA tests for recording settings
+    ara_playbook_labels:
+      - recording-tests
+  tasks:
+    - name: Retrieve the current playbook so we can get the ID
+      ara_playbook:
+      register: playbook_query
+
+    - name: Save the playbook id so we can re-use it easily
+      set_fact:
+        playbook_id: "{{ playbook_query.playbook.id | string }}"
+
+    - name: Recover data from ARA
+      set_fact:
+        playbook: "{{ lookup('ara_api', '/api/v1/playbooks/' + playbook_id) }}"
+        results: "{{ lookup('ara_api', '/api/v1/results?playbook=' + playbook_id) }}"
+
+    # The list search view for results does not provide the content.
+    # We must first retrieve it via the detailed view.
+    - name: Validate that every result is empty of content
+      vars:
+        _result: "{{ lookup('ara_api', '/api/v1/results/' + item.id | string) }}"
+      assert:
+        that:
+          - _result.id == item.id
+          - _result.content == {}
+      loop: "{{ results['results'] }}"
+
+    - name: Validate that the controller and user are set properly
+      assert:
+        that:
+          - playbook.controller == "test-controller"
+          - playbook.user == "test-user"
+        fail_msg: |
+          The controller or user aren't the expected values.
+          Were environment variables set before running the playbook ?

--- a/tests/test_tasks.yaml
+++ b/tests/test_tasks.yaml
@@ -75,6 +75,13 @@
     - name: Run lookups.yaml integration test
       command: "ansible-playbook -vvv {{ _test_root }}/lookups.yaml"
 
+    - name: Run record settings tests
+      environment:
+        ARA_RECORD_USER_NAME: "test-user"
+        ARA_RECORD_CONTROLLER_NAME: "test-controller"
+        ARA_RECORD_TASK_CONTENT: "false"
+      command: "ansible-playbook -vvv {{ _test_root }}/record_settings.yaml"
+
     - name: Run delegate_to integration tests
       command: "ansible-playbook -vvv {{ _test_root }}/delegate_to.yaml"
 


### PR DESCRIPTION
There are three new settings which needed some amount of testing coverage:
- ARA_RECORD_USER_NAME (to manually override the recorded user for a playbook)
- ARA_RECORD_CONTROLLER_NAME (to manually override the recorded controller for a playbook)
- ARA_RECORD_TASK_CONTENT (to prevent ara from recording task content)

This improves the coverage while fixing a gap that we had about controller and user name recording.

Fixes: https://github.com/ansible-community/ara/issues/506