### PR TITLE
zuul: bump version of ansible 8 to 8.3.0

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -119,7 +119,7 @@
       Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible 8 (ansible-core 2.15).
     vars:
       ara_tests_ansible_name: ansible
-      ara_tests_ansible_version: 8.1.0
+      ara_tests_ansible_version: 8.3.0
 
 - job:
     name: ara-basic-ansible-core-2.15


### PR DESCRIPTION
It is currently the latest version.