### PR TITLE
ui: fix wrong form url for task search

### DIFF
--- a/ara/ui/templates/partials/search/tasks.html
+++ b/ara/ui/templates/partials/search/tasks.html
@@ -16,7 +16,7 @@
 
       <div id="search_tasks_arguments" class="accordion-collapse collapse {% if expand_search %}show{% endif %}" data-bs-parent="#search_tasks">
         <div class="accordion-body">
-          <form action="{% url 'ui:index' %}" method="get">
+          <form action="{% url 'ui:task_index' %}" method="get">
           <!-- task action and name -->
           <div class="row g-2">
             <div class="col-md">


### PR DESCRIPTION
A copy/paste error snuck by during the refactor to bootstrap 5 and the task search ended up posting to the playbook search which was wrong.