### PR TITLE
requirements: adjust django requirement to >=3.2,<4.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,9 @@ ara.cli =
 
 [extras]
 server=
-    Django>=4.2,<4.3
+    # 3.2 LTS is supported until April 2024 after which we should lift to >=4.2
+    # https://github.com/ansible-community/ara/issues/485
+    Django>=3.2,<4.3
     djangorestframework>=3.9.1
     django-cors-headers
     django-filter


### PR DESCRIPTION
ara currently works with both the 3.2 and 4.2 LTS versions of django and django 3.2 is maintained until April 2024.

We can be flexible on the version of django for now.

Fixes: https://github.com/ansible-community/ara/issues/485