### PR TITLE
docs: bump version of django in docs/requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,7 +7,7 @@ sphinxcontrib-programoutput
 cliff
 
 # For ara-manage cli's programoutput, we need to include server extra dependencies from setup.cfg
-Django>=2.1.5,<3.0
+Django>=3.2,<4.3
 djangorestframework>=3.9.1
 django-cors-headers
 django-filter


### PR DESCRIPTION
This django requirement is used when building documentation and should match the version of django we have in the project's main requirements.