### PR TITLE
ui: Fix link to the API when browsing tasks

### DIFF
--- a/ara/ui/templates/partials/api_link.html
+++ b/ara/ui/templates/partials/api_link.html
@@ -9,6 +9,8 @@
   {% else %}
   <a href="{% url 'latesthost-list' %}" class="nav-link" target="_blank">API</a>
   {% endif %}
+{% elif page == "task_index" %}
+  <a href="{% url 'task-list' %}" class="nav-link" target="_blank">API</a>
 {% elif playbook.id %}
   <a href="{% url 'playbook-detail' pk=playbook.id %}" class="nav-link" target="_blank">API</a>
 {% elif result.id %}


### PR DESCRIPTION
It's intended that the API link changes based on the page.

The playbook list and host list links were fine but it seems we had forgotten about the task list link.