### PR TITLE
python3 -m gunicorn instead of /usr/local/bin/gunicorn as container entry command

### DIFF
--- a/contrib/container-images/centos-source.sh
+++ b/contrib/container-images/centos-source.sh
@@ -31,7 +31,7 @@ buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
 buildah config --env ARA_BASE_DIR=/opt/ara "${build}"
-buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && /usr/local/bin/gunicorn --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
+buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && python3 -m gunicorn --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
 buildah config --port 8000 "${build}"
 
 # Commit this container to an image name

--- a/contrib/container-images/fedora-pypi.sh
+++ b/contrib/container-images/fedora-pypi.sh
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 DEV_DEPENDENCIES="gcc python3-devel postgresql-devel mariadb-devel"
 
-# Builds an ARA API server container image using the latest PyPi packages on Fedora 36.
+# Builds an ARA API server container image using the latest PyPi packages on Fedora 38.
 build=$(buildah from quay.io/fedora/fedora:38)
 
 # Ensure everything is up to date and install requirements
@@ -21,7 +21,7 @@ buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
 buildah config --env ARA_BASE_DIR=/opt/ara "${build}"
-buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && /usr/local/bin/gunicorn --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
+buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && python3 -m gunicorn --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
 buildah config --port 8000 "${build}"
 
 # Commit this container to an image name

--- a/contrib/container-images/fedora-source.sh
+++ b/contrib/container-images/fedora-source.sh
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 DEV_DEPENDENCIES="gcc python3-devel postgresql-devel mariadb-devel"
 
-# Builds an ARA API server container image from checked out source on Fedora 36.
+# Builds an ARA API server container image from checked out source on Fedora 38.
 # Figure out source directory relative to the contrib/container-images directory
 SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 SOURCE_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd -P)
@@ -31,7 +31,7 @@ buildah run "${build}" -- /bin/bash -c "dnf remove -y ${DEV_DEPENDENCIES} && dnf
 
 # Set up the container to execute SQL migrations and run the API server with gunicorn
 buildah config --env ARA_BASE_DIR=/opt/ara "${build}"
-buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && /usr/local/bin/gunicorn --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
+buildah config --cmd "bash -c '/usr/local/bin/ara-manage migrate && python3 -m gunicorn --workers=4 --access-logfile - --bind 0.0.0.0:8000 ara.server.wsgi'" "${build}"
 buildah config --port 8000 "${build}"
 
 # Commit this container to an image name


### PR DESCRIPTION
To avoid import problems such as in https://github.com/ansible-community/ara/issues/406#issue-1330390967 or #514 it is more safe to call `gunicorn` via `python3 -m` same as it is done with `pip`