### PR TITLE
settings: fix deprecated use of .dump in ruamel.yaml

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -2,21 +2,21 @@
 - job:
     name: ara-tox-py3
     parent: tox
-    nodeset: ara-fedora-38
+    nodeset: ara-fedora-39
     vars:
       tox_envlist: py3
 
 - job:
     name: ara-tox-linters
     parent: tox
-    nodeset: ara-fedora-38
+    nodeset: ara-fedora-39
     vars:
       tox_envlist: linters
 
 - job:
     name: ara-tox-docs
     parent: base
-    nodeset: ara-fedora-38
+    nodeset: ara-fedora-39
     files:
       - doc/*
     run: tests/zuul_docs.yaml
@@ -44,7 +44,7 @@
 - job:
     name: ara-integration-container-base
     parent: ara-integration-base
-    nodeset: ara-fedora-38
+    nodeset: ara-fedora-39
     files:
       - ara/*
       - manage.py
@@ -113,13 +113,22 @@
         override-checkout: devel
 
 - job:
-    name: ara-basic-ansible-8
+    name: ara-basic-ansible-9
     parent: ara-ansible-integration-base
     description: |
       Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible 8 (ansible-core 2.15).
     vars:
       ara_tests_ansible_name: ansible
-      ara_tests_ansible_version: 8.3.0
+      ara_tests_ansible_version: 9.2.0
+
+- job:
+    name: ara-basic-ansible-core-2.16
+    parent: ara-ansible-integration-base
+    description: |
+      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible-core 2.16.
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.16
 
 - job:
     name: ara-basic-ansible-core-2.15
@@ -129,13 +138,4 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.15
-
-- job:
-    name: ara-basic-ansible-core-2.14
-    parent: ara-ansible-integration-base
-    description: |
-      Runs basic integration tests through the equivalent of "tox -e ansible-integration" with ansible-core 2.14.
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.14
 

--- a/.zuul.d/nodesets.yaml
+++ b/.zuul.d/nodesets.yaml
@@ -2,7 +2,7 @@
     name: ara-basic-nodeset
     nodes:
       - name: ara-api-server
-        label: ansible-cloud-fedora-38-tiny
+        label: cloud-fedora-39
     # or if testing multiple OS simultaneously:
     # groups:
     #  - name: ara-api-server
@@ -12,11 +12,11 @@
     #      - ubuntu-bionic-1vcpu
 
 - nodeset:
-    name: ara-fedora-38
+    name: ara-fedora-39
     nodes:
-      - name: fedora-38
-        label: ansible-cloud-fedora-38-tiny
+      - name: fedora-39
+        label: cloud-fedora-39
     groups:
       - name: ara-api-server
         nodes:
-          - fedora-38
+          - fedora-39

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -20,7 +20,7 @@
         - ara-basic-ansible-core-2.16
         - ara-basic-ansible-core-2.15
         - ara-container-images
-    post:
-      jobs:
-        - ara-container-images-dockerhub
-        - ara-container-images-quayio
+#    post:
+#      jobs:
+#        - ara-container-images-dockerhub
+#        - ara-container-images-quayio

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -7,18 +7,18 @@
         - ara-tox-docs
         - ara-basic-ansible-core-devel:
             voting: false
-        - ara-basic-ansible-8
+        - ara-basic-ansible-9
+        - ara-basic-ansible-core-2.16
         - ara-basic-ansible-core-2.15
-        - ara-basic-ansible-core-2.14
         - ara-container-images
     gate:
       jobs:
         - ara-tox-py3
         - ara-tox-linters
         - ara-tox-docs
-        - ara-basic-ansible-8
+        - ara-basic-ansible-9
+        - ara-basic-ansible-core-2.16
         - ara-basic-ansible-core-2.15
-        - ara-basic-ansible-core-2.14
         - ara-container-images
     post:
       jobs:

--- a/ara/api/tests/tests_utils.py
+++ b/ara/api/tests/tests_utils.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2022 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import pkg_resources
 from rest_framework.test import APITestCase
+
+from ara.setup import ara_version as ARA_VERSION
 
 
 class RootTestCase(APITestCase):
@@ -10,6 +11,6 @@ class RootTestCase(APITestCase):
         result = self.client.get("/api/")
         self.assertEqual(set(result.data.keys()), {"kind", "version", "api"})
         self.assertEqual(result.data["kind"], "ara")
-        self.assertEqual(result.data["version"], pkg_resources.get_distribution("ara").version)
+        self.assertEqual(result.data["version"], ARA_VERSION)
         self.assertEqual(len(result.data["api"]), 1)
         self.assertTrue(result.data["api"][0].endswith("/api/v1/"))

--- a/ara/server/settings.py
+++ b/ara/server/settings.py
@@ -9,12 +9,14 @@ import tzlocal
 from django.utils.crypto import get_random_string
 from dynaconf import LazySettings
 
-# dynaconf prefers ruamel.yaml but works with pyyaml
+# dynaconf prefers ruamel.yaml but historically we also used pyyaml
 # https://github.com/rochacbruno/dynaconf/commit/d5cf87cbbdf54625ccf1138a4e4c210956791e61
-try:
-    from ruamel import yaml as yaml
-except ImportError:
-    import yaml
+# ruamel.yaml >= 0.18 deprecated raw use of .dump
+# https://github.com/ansible-community/ara/issues/524
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="unsafe", pure=True)
+yaml.default_flow_style = False
 
 BASE_DIR = os.environ.get("ARA_BASE_DIR", os.path.expanduser("~/.ara/server"))
 DEFAULT_SETTINGS = os.path.join(BASE_DIR, "settings.yaml")
@@ -303,7 +305,7 @@ if not os.path.exists(DEFAULT_SETTINGS) and "ARA_SETTINGS" not in os.environ:
         )
         print("[ara] Writing default settings to %s" % DEFAULT_SETTINGS)
         settings_file.write(comment.lstrip())
-        yaml.dump({"default": SETTINGS}, settings_file, default_flow_style=False)
+        yaml.dump({"default": SETTINGS}, settings_file)
 
 if BASE_PATH:
     BASE_PATH = BASE_PATH.rstrip("/")

--- a/contrib/container-images/README.rst
+++ b/contrib/container-images/README.rst
@@ -27,9 +27,9 @@ You will need to install `buildah <https://github.com/containers/buildah/blob/ma
 
 The different scripts to build container images are available in the git repository:
 
-- fedora-distribution.sh_: Builds an image from Fedora 38 `distribution packages <https://koji.fedoraproject.org/koji/packageinfo?packageID=24394>`_
-- fedora-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on Fedora 38
-- fedora-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on Fedora 38
+- fedora-distribution.sh_: Builds an image from Fedora 39 `distribution packages <https://koji.fedoraproject.org/koji/packageinfo?packageID=24394>`_
+- fedora-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on Fedora 39
+- fedora-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on Fedora 39
 - centos-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on CentOS 9 Stream
 - centos-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on CentOS 9 Stream
 

--- a/contrib/container-images/fedora-distribution.sh
+++ b/contrib/container-images/fedora-distribution.sh
@@ -2,8 +2,8 @@
 # Copyright (c) 2023 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Builds an ARA API server container image from Fedora 38 distribution packages.
-build=$(buildah from quay.io/fedora/fedora:38)
+# Builds an ARA API server container image from Fedora 39 distribution packages.
+build=$(buildah from quay.io/fedora/fedora:39)
 
 # Get all updates, install the ARA API server, database backends and gunicorn application server
 # This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.

--- a/contrib/container-images/fedora-pypi.sh
+++ b/contrib/container-images/fedora-pypi.sh
@@ -3,8 +3,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 DEV_DEPENDENCIES="gcc python3-devel postgresql-devel mariadb-devel"
 
-# Builds an ARA API server container image using the latest PyPi packages on Fedora 38.
-build=$(buildah from quay.io/fedora/fedora:38)
+# Builds an ARA API server container image using the latest PyPi packages on Fedora 39.
+build=$(buildah from quay.io/fedora/fedora:39)
 
 # Ensure everything is up to date and install requirements
 buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-wheel postgresql libpq mariadb-connector-c"

--- a/contrib/container-images/fedora-source.sh
+++ b/contrib/container-images/fedora-source.sh
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 DEV_DEPENDENCIES="gcc python3-devel postgresql-devel mariadb-devel"
 
-# Builds an ARA API server container image from checked out source on Fedora 38.
+# Builds an ARA API server container image from checked out source on Fedora 39.
 # Figure out source directory relative to the contrib/container-images directory
 SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 SOURCE_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd -P)
@@ -14,7 +14,7 @@ python3 setup.py sdist
 sdist=$(ls dist/ara-*.tar.gz)
 popd
 
-build=$(buildah from quay.io/fedora/fedora:38)
+build=$(buildah from quay.io/fedora/fedora:39)
 
 # Ensure everything is up to date and install requirements
 buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-wheel postgresql libpq mariadb-connector-c"

--- a/tests/with_container_images.yaml
+++ b/tests/with_container_images.yaml
@@ -13,19 +13,19 @@
     images:
       # These are in chronological order of release so that we don't end up
       # running SQL migrations backwards during the tests.
-      - tag: fedora38-source-latest
+      - tag: fedora39-source-latest
         script: fedora-source.sh
         name: localhost/ara-api
       - tag: centos9-source-latest
         script: centos-source.sh
         name: localhost/ara-api
-      - tag: fedora38-pypi-latest
+      - tag: fedora39-pypi-latest
         script: fedora-pypi.sh
         name: localhost/ara-api
       - tag: centos9-pypi-latest
         script: centos-pypi.sh
         name: localhost/ara-api
-      - tag: fedora38-distribution-latest
+      - tag: fedora39-distribution-latest
         script: fedora-distribution.sh
         name: localhost/ara-api
   tasks:

--- a/tests/zuul_publish_container_images.yaml
+++ b/tests/zuul_publish_container_images.yaml
@@ -8,15 +8,15 @@
     destination: "{{ destination_repository | default('docker.io/recordsansible/ara-api') }}"
     images:
       # These images are meant to be provided by the "with_container_images.yaml" playbook
-      - tag: fedora38-source-latest
+      - tag: fedora39-source-latest
         name: localhost/ara-api
       - tag: centos9-source-latest
         name: localhost/ara-api
-      - tag: fedora38-pypi-latest
+      - tag: fedora39-pypi-latest
         name: localhost/ara-api
       - tag: centos9-pypi-latest
         name: localhost/ara-api
-      - tag: fedora38-distribution-latest
+      - tag: fedora39-distribution-latest
         name: localhost/ara-api
   tasks:
     - name: List built container images
@@ -28,9 +28,9 @@
         buildah tag {{ item.name }}:{{ item.tag }} {{ destination }}:{{ item.tag }}
       loop: "{{ images }}"
 
-    - name: Tag latest from fedora38-pypi-latest
+    - name: Tag latest from fedora39-pypi-latest
       command: |
-        buildah tag {{ destination }}:fedora38-pypi-latest {{ destination }}:latest
+        buildah tag {{ destination }}:fedora39-pypi-latest {{ destination }}:latest
 
     - name: Push latest
       command: |


### PR DESCRIPTION
ruamel.yaml>=0.18 deprecated the use of .dump which we historically used that maintained compatibility between pyyaml and ruamel.yaml.

We can eventually remove this pin when we change our usage of dump.

https://github.com/ansible-community/ara/issues/524