### PR TITLE
ui: fix displaying result diffs with "prepared" key

### DIFF
--- a/ara/ui/templatetags/diff_result.py
+++ b/ara/ui/templatetags/diff_result.py
@@ -9,13 +9,16 @@ from django import template
 register = template.Library()
 
 
-def render_diff(before="", after="", before_header="before", after_header="after"):
+def render_diff(before="", after="", prepared="", before_header="before", after_header="after"):
     """
     Renders a diff provided by Ansible task results
     """
     # fmt: off
-    # Some modules, such as file, might provide a diff in a dict format
-    if isinstance(before, dict) and isinstance(after, dict):
+    if prepared:
+        # Modules like apt, git or ios/eos provide pre-generated diff as string
+        return prepared.splitlines()
+    elif isinstance(before, dict) and isinstance(after, dict):
+        # Some modules, such as file, might provide a diff in a dict format
         return difflib.unified_diff(
             json.dumps(before, indent=4).splitlines(),
             json.dumps(after, indent=4).splitlines(),


### PR DESCRIPTION
This fixes diffs in task results that only have "prepared" key in them from looking like this:

![scr-20240305002825](https://github.com/ansible-community/ara/assets/227121/5566df00-916b-4215-84d6-490580107729)

To being properly formatted and colorized, like diffs with "before" and "after" keys in them look.

Ansible produces diffs with "prepared" key instead of before/after in plugins like git, apt, cli_config already.

But also some network devices (e.g. Arista EOS, Cisco IOS, etc) can only produce diffs like this between normalized candidate and running configurations, where it is tricky or impossible to do local diff, without on-device knowledge about configuration format normalization.
(I've bumped into this issue with arista.eos ansible collection in particular)

Thanks.