### PR TITLE
ui: Fix sorting playbook results by date and duration

### DIFF
--- a/ara/ui/templates/partials/tables/playbook_results.html
+++ b/ara/ui/templates/partials/tables/playbook_results.html
@@ -27,8 +27,12 @@
                 <tr style="height:50px;">
                   <th class="report-column">Report</th>
                   <th class="medium-status-column">Status</th>
-                  <th class="date-column">{% include "partials/sort_by_date.html" with arg="started" form_url="ui:playbook" %}</th>
-                  <th class="duration-column">{% include "partials/sort_by_duration.html" with form_url="ui:playbook" %}</th>
+                  <th class="date-column">
+                    <form action="{% url 'ui:playbook' playbook.id %}" method="get">{% include "partials/sort_by_date.html" with arg="started" %}</form>
+                  </th>
+                  <th class="duration-column">
+                    <form action="{% url 'ui:playbook' playbook.id %}" method="get">{% include "partials/sort_by_duration.html" %}
+                  </th>
                   <th>Host</th>
                   <th>Action</th>
                   <th>Task</th>


### PR DESCRIPTION
It used to be that sort_by_date and sort_by_duration accepted a "form_url" argument before 1.7.0 but it is no longer the case.

Like the playbook list, use an in-line form element instead.

Fixes: https://github.com/ansible-community/ara/issues/543