### PR TITLE
Docs: Add introduction, say what ARA does

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -8,6 +8,7 @@ Table of Contents
 .. toctree::
     :maxdepth: 3
 
+    Introduction <introduction>
     Getting started <getting-started>
     Ansible: configuration to use ARA <ansible-configuration>
     Ansible: plugins and use cases <ansible-plugins-and-use-cases>

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -1,0 +1,9 @@
+Introduction
+============
+
+ARA aims to do one thing and do it well: Record Ansible playbooks and provide
+you with the tools you need to make your playbook results intuitive for you and
+for your systems.
+
+The great thing about ARA is that it is not mutually exclusive with other
+software and systems you might already be using Ansible with today.


### PR DESCRIPTION
Copied from the FAQ, "Why ARA and not <X>"

(It's nice to have the docs begin by explaining what the software does.  :)