### PR TITLE
support logging on Python 3.13 fixed #546

### DIFF
--- a/ara/api/management/commands/prune.py
+++ b/ara/api/management/commands/prune.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        logger.warn("This command has been replaced by 'ara playbook prune' in 1.5. It will be removed in 1.6.")
+        logger.warning("This command has been replaced by 'ara playbook prune' in 1.5. It will be removed in 1.6.")
 
         client = options.get("client")
         endpoint = options.get("endpoint")

--- a/ara/cli/host.py
+++ b/ara/cli/host.py
@@ -212,7 +212,9 @@ class HostShow(ShowOne):
     def take_action(self, args):
         # TODO: Render json properly in pretty tables
         if args.with_facts and args.formatter == "table":
-            self.log.warn("Rendering using default table formatter, use '-f yaml' or '-f json' for improved display.")
+            self.log.warning(
+                "Rendering using default table formatter, use '-f yaml' or '-f json' for improved display."
+            )
 
         verify = False if args.insecure else True
         if args.ssl_ca:

--- a/ara/cli/playbook.py
+++ b/ara/cli/playbook.py
@@ -237,7 +237,9 @@ class PlaybookShow(ShowOne):
     def take_action(self, args):
         # TODO: Render json properly in pretty tables
         if args.formatter == "table":
-            self.log.warn("Rendering using default table formatter, use '-f yaml' or '-f json' for improved display.")
+            self.log.warning(
+                "Rendering using default table formatter, use '-f yaml' or '-f json' for improved display."
+            )
 
         verify = False if args.insecure else True
         if args.ssl_ca:

--- a/ara/cli/record.py
+++ b/ara/cli/record.py
@@ -134,7 +134,9 @@ class RecordShow(ShowOne):
     def take_action(self, args):
         # TODO: Render json properly in pretty tables
         if args.formatter == "table":
-            self.log.warn("Rendering using default table formatter, use '-f yaml' or '-f json' for improved display.")
+            self.log.warning(
+                "Rendering using default table formatter, use '-f yaml' or '-f json' for improved display."
+            )
 
         verify = False if args.insecure else True
         if args.ssl_ca:

--- a/ara/cli/result.py
+++ b/ara/cli/result.py
@@ -217,7 +217,9 @@ class ResultShow(ShowOne):
     def take_action(self, args):
         # TODO: Render json properly in pretty tables
         if args.with_content and args.formatter == "table":
-            self.log.warn("Rendering using default table formatter, use '-f yaml' or '-f json' for improved display.")
+            self.log.warning(
+                "Rendering using default table formatter, use '-f yaml' or '-f json' for improved display."
+            )
 
         verify = False if args.insecure else True
         if args.ssl_ca:

--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -472,7 +472,7 @@ class CallbackModule(CallbackBase):
             # https://github.com/ansible-community/ara/issues/185
             # https://github.com/ansible-community/ara/issues/265
             if len(play_vars["ara_playbook_name"]) >= 255:
-                self.log.warn("Truncating playbook name before recording: it's longer than 255 characters")
+                self.log.warning("Truncating playbook name before recording: it's longer than 255 characters")
 
             self.playbook = self.client.patch(
                 "/api/v1/playbooks/%s" % self.playbook["id"], name=play_vars["ara_playbook_name"][:254]
@@ -482,7 +482,7 @@ class CallbackModule(CallbackBase):
         # https://github.com/ansible-community/ara/issues/185
         # https://github.com/ansible-community/ara/issues/265
         if len(play.name) >= 255:
-            self.log.warn("Truncating play name before recording: it's longer than 255 characters")
+            self.log.warning("Truncating play name before recording: it's longer than 255 characters")
             play.name = play.name[:254]
 
         labels = self.default_labels + self.argument_labels
@@ -680,7 +680,7 @@ class CallbackModule(CallbackBase):
         expected_labels = []
         for label in labels:
             if len(label) >= 255:
-                self.log.warn("Truncating label name before recording: it's longer than 255 characters (%s)" % label)
+                self.log.warning("Truncating label name before recording: it's longer than 255 characters (%s)" % label)
                 label = label[:254]
             expected_labels.append(label)
 
@@ -724,7 +724,7 @@ class CallbackModule(CallbackBase):
         if len(host) >= 255:
             # Only warn about this once so we don't print a warning on every task
             if host not in self.warned_about_host_length:
-                self.log.warn("Truncating hostname before recording: it's longer than 255 characters (%s)" % host)
+                self.log.warning("Truncating hostname before recording: it's longer than 255 characters (%s)" % host)
                 self.warned_about_host_length.append(host)
             host = host[:254]
 

--- a/ara/server/wsgi.py
+++ b/ara/server/wsgi.py
@@ -65,7 +65,7 @@ def distributed_sqlite(environ, start_response):
         return default_application(environ, start_response)
 
     if prefix not in path_info:
-        logger.warn("Ignoring request: URL does not contain delegated prefix (%s)" % prefix)
+        logger.warning("Ignoring request: URL does not contain delegated prefix (%s)" % prefix)
         return handle_404(start_response)
 
     # Slice path_info up until after the prefix to obtain the requested directory
@@ -75,16 +75,16 @@ def distributed_sqlite(environ, start_response):
     # Make sure we aren't escaping outside the root and the directory exists
     db_dir = os.path.abspath(os.path.join(root, fs_path.lstrip("/")))
     if not db_dir.startswith(root):
-        logger.warn("Ignoring request: path is outside the root (%s)" % db_dir)
+        logger.warning("Ignoring request: path is outside the root (%s)" % db_dir)
         return handle_404(start_response)
     elif not os.path.exists(db_dir):
-        logger.warn("Ignoring request: database directory not found (%s)" % db_dir)
+        logger.warning("Ignoring request: database directory not found (%s)" % db_dir)
         return handle_404(start_response)
 
     # Find the database file and make sure it exists
     db_file = os.path.join(db_dir, "ansible.sqlite")
     if not os.path.exists(db_file):
-        logger.warn("Ignoring request: database file not found (%s)" % db_file)
+        logger.warning("Ignoring request: database file not found (%s)" % db_file)
         return handle_404(start_response)
 
     # Tell Django about the new URLs it should be using


### PR DESCRIPTION
As linked on https://github.com/ansible-community/ara/issues/546, Python 3.13 finally removed the deprecate `.warn()`, so we now need to use `.warning()` instead.