### PR TITLE
setup.cfg: make ruamel.yaml dependency explicit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,9 @@ server=
     # dynaconf 3.1.3 had a regression https://github.com/ansible-community/ara/issues/212
     # dynaconf dropped support for py35 at version 3.0.0: https://github.com/ansible-community/ara/issues/370
     dynaconf[yaml]>=3.0.0,!=3.1.3,<4.0.0
+    # dynaconf[yaml] should recover ruamel.yaml but this isn't always the case (i.e, Fedora koji)
+    # Make the dependency explicit.
+    ruamel.yaml
     tzlocal>=4.0
     whitenoise
     pygments


### PR DESCRIPTION
It should generally be picked up by the dynaconf yaml extras but it was found to not always be the case (i.e: Fedora koji) so make it explicit since there is no harm in doing so.