### PR TITLE
docs: make readthedocs use ubuntu 22.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-24.04
+  os: ubuntu-22.04
   tools:
     python: "3.12"
     # You can also specify other tool versions:


### PR DESCRIPTION
It turns out that there is no image for 24.04 yet.