### PR TITLE
Docs refresh

### DIFF
--- a/doc/changelog-release-notes.sh
+++ b/doc/changelog-release-notes.sh
@@ -23,6 +23,7 @@ function smallheader() {
 
 echo ".."
 echo "  note: generated through doc/changelog-release-notes.sh"
+echo ".. _changelog-release-notes:"
 echo
 
 header "Changelog and release notes"

--- a/doc/source/changelog-release-notes.rst
+++ b/doc/source/changelog-release-notes.rst
@@ -1,5 +1,6 @@
 ..
   note: generated through doc/changelog-release-notes.sh
+.. _changelog-release-notes:
 
 Changelog and release notes
 ***************************

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "ara"
-copyright = "2022, ARA Records Ansible authors"
+copyright = "2024, ARA Records Ansible authors"
 author = "ARA Records Ansible authors"
 
 # The short X.Y version.

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -1,3 +1,5 @@
+.. _contributing:
+
 Contributing to ARA
 ===================
 

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -1,3 +1,5 @@
+.. _faq:
+
 FAQ
 ===
 
@@ -7,8 +9,8 @@ Where is the source code ?
 ARA is currently composed of three different free and open source projects:
 
 - https://github.com/ansible-community/ara for the REST API server and Ansible plugins
-- https://github.com/ansible-community/ara-web for the standalone web interface
 - https://github.com/ansible-community/ara-infra for project-specific infrastructure needs (such as the `ara.recordsansible.org <https://ara.recordsansible.org>`_ website)
+- https://github.com/ansible-community/ara-collection for the Ansible collection of ara
 
 What's an Ansible callback ?
 ----------------------------
@@ -75,16 +77,20 @@ Can I set up the different components of ARA on different servers ?
 
 Yes.
 
-The defaults are set to have the callback use the offline API client which
-expects the server dependencies installed and the data is saved to a local
-sqlite database.
+By default ara operates "offline" on localhost, recording Ansible playbook results
+to a local sqlite database without requiring users to start a server.
 
-However, the callback can also be configured to send data to a specified API
-server address and the API server can be configured to use a remote database
-server such as PostgreSQL or MySQL.
+According to preference or use case, the data can be saved to local (or remote)
+MySQL or PostgreSQL databases instead.
 
-The web client interface provided by ara-web_ is stateless and requires an API
-server address to connect to.
-It can be installed anywhere that has access to the API server.
+The ara server (based on django & django-rest-framework) provides the reporting
+interface as well as the API used by the ara Ansible plugins.
 
-.. _ara-web: https://github.com/ansible-community/ara-web
+The server's state is stored in the database and it can be self hosted anywhere.
+Running multiple servers allows for load balancing, scalability and high availability.
+
+To make use of a persistent server, configure the ara Ansible plugins with:
+
+- ``export ARA_API_CLIENT=http``
+- ``export ARA_API_SERVER=http://ara.example.org``
+

--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -1,125 +1,20 @@
 Getting started
 ===============
 
-Requirements
-------------
+The `README <https://github.com/ansible-community/ara/blob/master/README.md>`_ is the best place to get started.
 
-- Any recent Linux distribution or Mac OS with python >=3.5 available
-- The ara Ansible plugins must be installed for the same python interpreter as Ansible itself
+It will tell you about:
 
-.. note::
-    For RHEL 7 and CentOS 7 it is recommended to run the API server in a container due to missing or outdated dependencies.
-    See this `issue <https://github.com/ansible-community/ara/issues/99>`_ for more information.
+- `what ara is <https://github.com/ansible-community/ara/blob/master/README.md#ara-records-ansible>`_
+- `what it does <https://github.com/ansible-community/ara/blob/master/README.md#about-ara>`_
+- `how it works <https://github.com/ansible-community/ara/blob/master/README.md#how-it-works>`_
+- `what dependencies it needs <https://github.com/ansible-community/ara/blob/master/README.md#requirements>`_
+- `how to get started <https://github.com/ansible-community/ara/blob/master/README.md#getting-started>`_
+- `a live demo <https://github.com/ansible-community/ara/blob/master/README.md#live-demo>`_
+- this documentation, the :ref:`troubleshooting guide <troubleshooting>` as well as :ref:`changelog and release notes <changelog-release-notes>`
+- `where the project community hangs out <https://ara.recordsansible.org/community/>`_
+- :ref:`how to contribute <contributing>`
+- the `project blog <https://ara.recordsansible.org/blog/>`_ with development news, release note highlights, tips, benchmarks and more
+- the `project authors and contributors <https://github.com/ansible-community/ara/graphs/contributors>`_
+- the open source license (`GPLv3 <https://github.com/ansible-community/ara/blob/master/LICENSE>`_)
 
-Recording playbooks without an API server
------------------------------------------
-
-The default API client, ``offline``, requires API server dependencies to be installed but does not need the API server
-to be running in order to query or send data.
-
-With defaults and using a local sqlite database:
-
-.. code-block:: bash
-
-    # Install Ansible and ARA (with API server dependencies) for the current user
-    python3 -m pip install --user ansible "ara[server]"
-
-    # Configure Ansible to use the ARA callback plugin
-    export ANSIBLE_CALLBACK_PLUGINS="$(python3 -m ara.setup.callback_plugins)"
-
-    # Run an Ansible playbook
-    ansible-playbook playbook.yaml
-
-    # Use the CLI to see recorded playbooks
-    ara playbook list
-
-    # Start the built-in development server to browse recorded results
-    ara-manage runserver
-
-Recording playbooks with an API server
---------------------------------------
-
-When running Ansible from multiple servers or locations, data can be aggregated by running the API server as a service
-and configuring the ARA Ansible callback plugin to use the ``http`` API client with the API server endpoint.
-
-The API server is a relatively simple django web application written in python that can run with WSGI application
-servers such as gunicorn, uwsgi or mod_wsgi.
-
-Alternatively, the API server can also run from a container image such as the one available on
-`DockerHub <https://hub.docker.com/r/recordsansible/ara-api>`_:
-
-.. code-block:: bash
-
-    # Create a directory for a volume to store settings and a sqlite database
-    mkdir -p ~/.ara/server
-
-    # Start an API server with podman from the image on DockerHub:
-    podman run --name api-server --detach --tty \
-      --volume ~/.ara/server:/opt/ara:z -p 8000:8000 \
-      docker.io/recordsansible/ara-api:latest
-
-    # or with docker:
-    docker run --name api-server --detach --tty \
-      --volume ~/.ara/server:/opt/ara:z -p 8000:8000 \
-      docker.io/recordsansible/ara-api:latest
-
-Once the server is running, Ansible playbook results can be sent to it by configuring the ARA callback plugin:
-
-.. code-block:: bash
-
-    # Install Ansible and ARA (without API server dependencies) for the current user
-    python3 -m pip install --user ansible ara
-
-    # Configure Ansible to use the ARA callback plugin
-    export ANSIBLE_CALLBACK_PLUGINS="$(python3 -m ara.setup.callback_plugins)"
-
-    # Set up the ARA callback to know where the API server is located
-    export ARA_API_CLIENT="http"
-    export ARA_API_SERVER="http://127.0.0.1:8000"
-
-    # Run an Ansible playbook
-    ansible-playbook playbook.yaml
-
-    # Use the CLI to see recorded playbooks
-    ara playbook list
-
-Data will be available on the API server in real time as the playbook progresses and completes.
-
-Read more about how container images are built and how to run them :ref:`here <container-images>`.
-
-Installing from source
-----------------------
-
-ara can be installed from source in order to preview and test unreleased features and improvements:
-
-.. code-block:: bash
-
-    # Without the API server dependencies
-    pip install --user git+https://github.com/ansible-community/ara
-
-    # With the API server dependencies
-    # (Extras suffixes don't work when supplying the direct git URL)
-    git clone https://github.com/ansible-community/ara /tmp/ara-src
-    pip install --user "/tmp/ara-src[server]"
-
-Installing from distribution packages
--------------------------------------
-
-ara is fully packaged for Fedora_, OpenSUSE_ as well as Debian_.
-
-There is also a package without the API server available on RHEL 8/CentOS 8 EPEL_.
-This package contains the Ansible plugins as well as the API clients which are sufficient to query or send data to a
-remote API server.
-
-.. _Fedora: https://koji.fedoraproject.org/koji/packageinfo?packageID=24394
-.. _OpenSUSE: https://build.opensuse.org/package/show/devel:languages:python/python-ara
-.. _Debian: https://tracker.debian.org/pkg/python-ara
-.. _EPEL: https://koji.fedoraproject.org/koji/packageinfo?packageID=24394
-
-Installing with Ansible roles
------------------------------
-
-A collection of Ansible roles for deploying a production-ready ara API server is available on
-`Ansible Galaxy <https://galaxy.ansible.com/recordsansible/ara>`_.
-
-For more information as well as documentation, see the collection GitHub repository: https://github.com/ansible-community/ara-collection/

--- a/doc/source/troubleshooting.rst
+++ b/doc/source/troubleshooting.rst
@@ -1,3 +1,5 @@
+.. _troubleshooting:
+
 Troubleshooting
 ===============
 
@@ -27,7 +29,7 @@ In order to retrieve the tracebacks, run these commands with increased verbosity
     # ...
     TASK [Gathering Facts] *****************************************************
     [WARNING]: Failure using method (v2_playbook_on_task_start) in callback plugin (<ansible.plugins.callback.ara_default.CallbackModule object at 0x7f1e7fd5ce50>):
-    Callback Exception: 
+    Callback Exception:
       File "/usr/lib/python3.9/site-packages/ansible/executor/task_queue_manager.py", line 389, in send_callback
         method(*new_args, **kwargs)
       File "/usr/lib/python3.9/site-packages/ara/plugins/callback/ara_default.py", line 354, in v2_playbook_on_task_start


### PR DESCRIPTION
The getting started guide was originally a copy from the README
and it accidently became stale and out of date as the README was
improved and maintained.

We can make the README even better eventually and there shouldn't
be two sources of truth.

Let's keep the README for this and link to it instead.

ara-web has been archived in February 2023, update the docs to remove
it and add ara-collection which was missing.

Take the opportunity to refresh the question about different components
of ara running on different servers.