### PR TITLE
Catch SIGINT and SIGTERM, record interrupted playbooks as 'expired'

### DIFF
--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -336,7 +336,7 @@ class CallbackModule(CallbackBase):
 
         def handler(sig, frame):
             ended = datetime.datetime.now(datetime.timezone.utc).isoformat()
-            status = "failed"
+            status = "expired"
             self.client.patch(
                 "/api/v1/playbooks/%s" % self.playbook["id"],
                 status=status,


### PR DESCRIPTION
Originally: https://github.com/ansible-community/ara/pull/559 (thanks @Nudin)

> This will catch SIGINT/SIGTERM and send an update to the ara server, so
that the playbook does not continue to be shown as running indefinitely
but will report failed. See https://github.com/ansible-community/ara/issues/556
> After sending the update to the server, it executes any handler that where
configured so far in order not to interfere with other parts of
ansible/ansible plugins or if none was present, exit with the appropriate exit code.

This is a great improvement over eventually expiring playbooks that were interrupted with the CLI: https://github.com/ansible-community/ara/blob/master/ara/cli/expire.py

I am sure some interruptions will not be salvageable depending on how bad things were interrupted or crashed, but this should take care of a substantial amount of them.