### PR TITLE
client: allow using utf-8 usernames and passwords

### DIFF
--- a/ara/clients/utils.py
+++ b/ara/clients/utils.py
@@ -22,7 +22,7 @@ def get_client(
     """
     auth = None
     if username is not None and password is not None:
-        auth = HTTPBasicAuth(username, password)
+        auth = HTTPBasicAuth(username.encode('utf-8'), password.encode('utf-8'))
 
     # Verify can be a bool (to ignore SSL verification or not)
     # or the path to a certificate authority

--- a/ara/clients/utils.py
+++ b/ara/clients/utils.py
@@ -22,7 +22,7 @@ def get_client(
     """
     auth = None
     if username is not None and password is not None:
-        auth = HTTPBasicAuth(username.encode('utf-8'), password.encode('utf-8'))
+        auth = HTTPBasicAuth(username.encode("utf-8"), password.encode("utf-8"))
 
     # Verify can be a bool (to ignore SSL verification or not)
     # or the path to a certificate authority


### PR DESCRIPTION
It looks like requests supports utf-8, but only if it is pre-encoded by the caller. Otherwise, it tries to encode both parameters using latin-1.

See 
https://github.com/psf/requests/blob/a3ce6f007597f14029e6b6f54676c34196aa050e/src/requests/auth.py#L56-L60 https://github.com/psf/requests/issues/3662
https://github.com/pallets/werkzeug/issues/945