### PR TITLE
container-images: bump fedora images to fedora:40

### DIFF
--- a/contrib/container-images/README.rst
+++ b/contrib/container-images/README.rst
@@ -27,9 +27,9 @@ You will need to install `buildah <https://github.com/containers/buildah/blob/ma
 
 The different scripts to build container images are available in the git repository:
 
-- fedora-distribution.sh_: Builds an image from Fedora 39 `distribution packages <https://koji.fedoraproject.org/koji/packageinfo?packageID=24394>`_
-- fedora-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on Fedora 39
-- fedora-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on Fedora 39
+- fedora-distribution.sh_: Builds an image from Fedora 40 `distribution packages <https://koji.fedoraproject.org/koji/packageinfo?packageID=24394>`_
+- fedora-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on Fedora 40
+- fedora-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on Fedora 40
 - centos-pypi.sh_: Builds an image from `PyPi <https://pypi.org/project/ara>`_ packages on CentOS 9 Stream
 - centos-source.sh_: Builds an image from `git source <https://github.com/ansible-community/ara>`_ on CentOS 9 Stream
 

--- a/contrib/container-images/fedora-distribution.sh
+++ b/contrib/container-images/fedora-distribution.sh
@@ -2,8 +2,8 @@
 # Copyright (c) 2023 The ARA Records Ansible authors
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Builds an ARA API server container image from Fedora 39 distribution packages.
-build=$(buildah from quay.io/fedora/fedora:39)
+# Builds an ARA API server container image from Fedora 40 distribution packages.
+build=$(buildah from quay.io/fedora/fedora:40)
 
 # Get all updates, install the ARA API server, database backends and gunicorn application server
 # This lets users swap easily from the sqlite default to mysql or postgresql just by tweaking settings.yaml.

--- a/contrib/container-images/fedora-pypi.sh
+++ b/contrib/container-images/fedora-pypi.sh
@@ -3,8 +3,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 DEV_DEPENDENCIES="gcc python3-devel postgresql-devel mariadb-devel"
 
-# Builds an ARA API server container image using the latest PyPi packages on Fedora 39.
-build=$(buildah from quay.io/fedora/fedora:39)
+# Builds an ARA API server container image using the latest PyPi packages on Fedora 40.
+build=$(buildah from quay.io/fedora/fedora:40)
 
 # Ensure everything is up to date and install requirements
 buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-wheel postgresql libpq mariadb-connector-c"

--- a/contrib/container-images/fedora-source.sh
+++ b/contrib/container-images/fedora-source.sh
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 DEV_DEPENDENCIES="gcc python3-devel postgresql-devel mariadb-devel"
 
-# Builds an ARA API server container image from checked out source on Fedora 39.
+# Builds an ARA API server container image from checked out source on Fedora 40.
 # Figure out source directory relative to the contrib/container-images directory
 SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 SOURCE_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd -P)
@@ -14,7 +14,7 @@ python3 setup.py sdist
 sdist=$(ls dist/ara-*.tar.gz)
 popd
 
-build=$(buildah from quay.io/fedora/fedora:39)
+build=$(buildah from quay.io/fedora/fedora:40)
 
 # Ensure everything is up to date and install requirements
 buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install -y which python3-pip python3-wheel postgresql libpq mariadb-connector-c"

--- a/tests/with_container_images.yaml
+++ b/tests/with_container_images.yaml
@@ -13,19 +13,19 @@
     images:
       # These are in chronological order of release so that we don't end up
       # running SQL migrations backwards during the tests.
-      - tag: fedora39-source-latest
+      - tag: fedora40-source-latest
         script: fedora-source.sh
         name: localhost/ara-api
       - tag: centos9-source-latest
         script: centos-source.sh
         name: localhost/ara-api
-      - tag: fedora39-pypi-latest
+      - tag: fedora40-pypi-latest
         script: fedora-pypi.sh
         name: localhost/ara-api
       - tag: centos9-pypi-latest
         script: centos-pypi.sh
         name: localhost/ara-api
-      - tag: fedora39-distribution-latest
+      - tag: fedora40-distribution-latest
         script: fedora-distribution.sh
         name: localhost/ara-api
   tasks:

--- a/tests/zuul_publish_container_images.yaml
+++ b/tests/zuul_publish_container_images.yaml
@@ -8,15 +8,15 @@
     destination: "{{ destination_repository | default('docker.io/recordsansible/ara-api') }}"
     images:
       # These images are meant to be provided by the "with_container_images.yaml" playbook
-      - tag: fedora39-source-latest
+      - tag: fedora40-source-latest
         name: localhost/ara-api
       - tag: centos9-source-latest
         name: localhost/ara-api
-      - tag: fedora39-pypi-latest
+      - tag: fedora40-pypi-latest
         name: localhost/ara-api
       - tag: centos9-pypi-latest
         name: localhost/ara-api
-      - tag: fedora39-distribution-latest
+      - tag: fedora40-distribution-latest
         name: localhost/ara-api
   tasks:
     - name: List built container images
@@ -28,9 +28,9 @@
         buildah tag {{ item.name }}:{{ item.tag }} {{ destination }}:{{ item.tag }}
       loop: "{{ images }}"
 
-    - name: Tag latest from fedora39-pypi-latest
+    - name: Tag latest from fedora40-pypi-latest
       command: |
-        buildah tag {{ destination }}:fedora39-pypi-latest {{ destination }}:latest
+        buildah tag {{ destination }}:fedora40-pypi-latest {{ destination }}:latest
 
     - name: Push latest
       command: |


### PR DESCRIPTION
39 is starting to be old with 41 just recently released.

We will eventually update to 41, let's just bump a single release for now.