### PR TITLE
Install tzdata when installing ara[server]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,9 @@ server=
     django-cors-headers
     django-filter
     django-health-check
+    # Django, via ZoneInfo, will attempt to load tzdata, but it isn't installed,
+    # Make it explicit for ara users.
+    tzdata
     # dynaconf 3.1.3 had a regression https://github.com/ansible-community/ara/issues/212
     # dynaconf dropped support for py35 at version 3.0.0: https://github.com/ansible-community/ara/issues/370
     dynaconf[yaml]>=3.0.0,!=3.1.3,<4.0.0


### PR DESCRIPTION
Starting with Django 4, Django will use either pytz or tzdata for timezone information via ZoneInfo.  However the ZoneInfo defaults to using tzdata. Typically this comes from the OS distribution but that isn't guaranteed. With that in mind let's install it alongside ara.

This will prevent tracebacks like:
---
Using /etc/ansible/ansible.cfg as config file
Operations to perform:
  Apply all migrations: admin, api, auth, contenttypes, db, sessions
Running migrations:
  No migrations to apply.
Traceback (most recent call last):
  File "/usr/lib/python3.10/zoneinfo/_common.py", line 12, in load_tzdata
    return importlib.resources.open_binary(package_name, resource_name)
  File "/usr/lib/python3.10/importlib/resources.py", line 43, in open_binary
    package = _common.get_package(package)
  File "/usr/lib/python3.10/importlib/_common.py", line 66, in get_package
    resolved = resolve(package)
  File "/usr/lib/python3.10/importlib/_common.py", line 57, in resolve
    return cand if isinstance(cand, types.ModuleType) else importlib.import_module(cand)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'tzdata'
---