### PR TITLE
Client: Enable to ignore all facts

### DIFF
--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -848,7 +848,7 @@ class CallbackModule(CallbackBase):
                 for fact in self.ignored_facts:
                     if fact in results["ansible_facts"]:
                         self.log.debug("Ignoring fact: %s" % fact)
-                        results["ansible_facts"][fact] = "Not saved by ARA as configured by 'ignored_facts'"
+                        results["ansible_facts"][fact] = ignored_facts_hint
 
         # Note: ignore_errors might be None instead of a boolean
         ignore_errors = kwargs.get("ignore_errors", False) or False

--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -838,10 +838,17 @@ class CallbackModule(CallbackBase):
 
         # Sanitize facts
         if "ansible_facts" in results:
-            for fact in self.ignored_facts:
-                if fact in results["ansible_facts"]:
-                    self.log.debug("Ignoring fact: %s" % fact)
-                    results["ansible_facts"][fact] = "Not saved by ARA as configured by 'ignored_facts'"
+            ignored_facts_hint = "Not saved by ARA as configured by 'ignored_facts'"
+
+            if "all" in self.ignored_facts:
+                self.log.debug("Ignoring all facts")
+                results["ansible_facts"] = {"all": ignored_facts_hint}
+
+            else:
+                for fact in self.ignored_facts:
+                    if fact in results["ansible_facts"]:
+                        self.log.debug("Ignoring fact: %s" % fact)
+                        results["ansible_facts"][fact] = "Not saved by ARA as configured by 'ignored_facts'"
 
         # Note: ignore_errors might be None instead of a boolean
         ignore_errors = kwargs.get("ignore_errors", False) or False


### PR DESCRIPTION
The Ansible-facts `gather_subset` allows for the value `all` to be supplied: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/setup_module.html#parameter-gather_subset

It would be logical that ARA allows users to ignore all facts the same way.
This PR adds that functionality.

This is especially useful as some facts are dynamically named - like network-interface facts.