### PR TITLE
Client: Enable to supply labels as inventory-vars

### DIFF
--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -518,6 +518,16 @@ class CallbackModule(CallbackBase):
                 labels.extend(play_vars["ara_playbook_labels"].split(","))
             else:
                 raise TypeError("ara_playbook_labels must be a list or a comma-separated string")
+
+        for host in play_vars["ansible_play_hosts"]:
+            if "ara_playbook_labels" in play_vars["hostvars"][host]:
+                if isinstance(play_vars["hostvars"][host]["ara_playbook_labels"], list):
+                    labels.extend(play_vars["hostvars"][host]["ara_playbook_labels"])
+                elif isinstance(play_vars["hostvars"][host]["ara_playbook_labels"], str):
+                    labels.extend(play_vars["hostvars"][host]["ara_playbook_labels"].split(","))
+                else:
+                    raise TypeError("ara_playbook_labels must be a list or a comma-separated string")
+
         if labels:
             self._submit_thread("global", self._set_playbook_labels, labels)
 

--- a/ara/plugins/callback/ara_default.py
+++ b/ara/plugins/callback/ara_default.py
@@ -519,7 +519,7 @@ class CallbackModule(CallbackBase):
             else:
                 raise TypeError("ara_playbook_labels must be a list or a comma-separated string")
 
-        for host in play_vars["ansible_play_hosts"]:
+        for host in play_vars["ansible_play_hosts_all"]:
             if "ara_playbook_labels" in play_vars["hostvars"][host]:
                 if isinstance(play_vars["hostvars"][host]["ara_playbook_labels"], list):
                     labels.extend(play_vars["hostvars"][host]["ara_playbook_labels"])

--- a/doc/source/ansible-plugins-and-use-cases.rst
+++ b/doc/source/ansible-plugins-and-use-cases.rst
@@ -93,6 +93,8 @@ or as extra-vars:
         -e ara_playbook_name="deploy prod" \
         -e ara_playbook_labels=deploy,prod
 
+You can also set the :code:`ara_playbook_labels` variable in your inventory. In that case all configured labels of the processed hosts are set.
+
 Once set, they can be searched for in the UI, the API:
 
 - ``/api/v1/playbooks?name=prod``


### PR DESCRIPTION
ARA-Labels can currently only be set inside a playbook or as extra-vars.

As Ansible uses the inventory-system to dynamically set variables - it would make sense to allow users to set those labels inside their inventory.
This PR adds exactly that functionality.