### PR TITLE
containers: publish new fedora41 tags

### DIFF
--- a/tests/with_container_images.yaml
+++ b/tests/with_container_images.yaml
@@ -13,19 +13,19 @@
     images:
       # These are in chronological order of release so that we don't end up
       # running SQL migrations backwards during the tests.
-      - tag: fedora40-source-latest
+      - tag: fedora41-source-latest
         script: fedora-source.sh
         name: localhost/ara-api
       - tag: centos9-source-latest
         script: centos-source.sh
         name: localhost/ara-api
-      - tag: fedora40-pypi-latest
+      - tag: fedora41-pypi-latest
         script: fedora-pypi.sh
         name: localhost/ara-api
       - tag: centos9-pypi-latest
         script: centos-pypi.sh
         name: localhost/ara-api
-      - tag: fedora40-distribution-latest
+      - tag: fedora41-distribution-latest
         script: fedora-distribution.sh
         name: localhost/ara-api
   tasks:

--- a/tests/zuul_publish_container_images.yaml
+++ b/tests/zuul_publish_container_images.yaml
@@ -8,15 +8,15 @@
     destination: "{{ destination_repository | default('docker.io/recordsansible/ara-api') }}"
     images:
       # These images are meant to be provided by the "with_container_images.yaml" playbook
-      - tag: fedora40-source-latest
+      - tag: fedora41-source-latest
         name: localhost/ara-api
       - tag: centos9-source-latest
         name: localhost/ara-api
-      - tag: fedora40-pypi-latest
+      - tag: fedora41-pypi-latest
         name: localhost/ara-api
       - tag: centos9-pypi-latest
         name: localhost/ara-api
-      - tag: fedora40-distribution-latest
+      - tag: fedora41-distribution-latest
         name: localhost/ara-api
   tasks:
     - name: List built container images
@@ -28,9 +28,9 @@
         buildah tag {{ item.name }}:{{ item.tag }} {{ destination }}:{{ item.tag }}
       loop: "{{ images }}"
 
-    - name: Tag latest from fedora40-pypi-latest
+    - name: Tag latest from fedora41-pypi-latest
       command: |
-        buildah tag {{ destination }}:fedora40-pypi-latest {{ destination }}:latest
+        buildah tag {{ destination }}:fedora41-pypi-latest {{ destination }}:latest
 
     - name: Push latest
       command: |


### PR DESCRIPTION
In 18669af186b3e60cc8780e62b7fdc9f231b60ae8 we updated the base image of the container images but we didn't actually publish them under the new fedora41 tags because we forgot to update these.